### PR TITLE
ReDoc now supports V3

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -103,7 +103,7 @@
   link: https://rebilly.github.io/ReDoc/
   description: OpenAPI/Swagger-generated API Reference Documentation
   v2: true
-  v3_progress_link: https://github.com/Rebilly/ReDoc/issues/327
+  v3: true
 
 - name: widdershins
   category: documentation


### PR DESCRIPTION
The linked issue for ReDoc to support v3 is closed. Updating the tools list to reflect this.