### PR TITLE
Added new parser/validator Node.js library

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -282,12 +282,21 @@
   description: Swagger 1.0, 1.1, 1.2, 2.0 to OpenAPI Specification parser
   v2: true
 
+- name: BigstickCarpet/swagger-parser
+  category: parsers
+  github: https://github.com/BigstickCarpet/swagger-parser
+  language: Node.js
+  description: Swagger/OpenAPI 2.0 and 3.0 parser and validator. Can also bundle multiple files into one via `$ref`.
+  v2: true
+  v3: true
+
 - name: BigstickCarpet/swagger-cli
   category: parsers
   github: https://github.com/BigstickCarpet/swagger-cli
   language: Node.js / CLI
   description: A handy cli tool for validating JSON or YAML files schema files that respects $ref
   v2: true
+  v3: true
 
 - name: KaiZen OpenAPI Parser
   github: https://github.com/RepreZen/KaiZen-OpenApi-Parser


### PR DESCRIPTION
Added a new entry for the [BigstickCarpet/swagger-parser library for Node.js](https://github.com/BigstickCarpet/swagger-parser).  I also updated the existing entry for [BigstickCarpet/swagger-cli](https://github.com/BigstickCarpet/swagger-cli) to indicate that it now supports OpenAPI 3.0