### PR TITLE
Added APIMatic in Documentation and SDK Generator's section

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -65,6 +65,14 @@
 
 #  Documentation Viewers/Consoles
 
+- name: APIMatic Developer Experience Portal
+  category: documentation
+  link: https://apimatic.io/developer-experience-portal
+  language: SaaS
+  description: Customizable developer portals packed with language specific documentation, client libraries, code samples, an API console and much more.
+  v2: true
+  v3: true
+
 - name: Kong Enterprise Edition
   category: documentation
   link: https://konghq.com/kong-enterprise-edition/
@@ -379,6 +387,15 @@
 #
 
 # SDK Generators
+
+- name: APIMatic CodeGen
+  category: sdk
+  language: SaaS
+  link: https://apimatic.io/code-generation-as-a-service
+  description:  Bring in your API description (OAI v2/v3, RAML, API Blueprint, WSDL, etc.) to generate fully functional SDKs in over 10 languages. 
+  v2: true
+  v3: true
+
 - name: janephp/open-api
   category: sdk
   language: PHP


### PR DESCRIPTION
APIMatic offers a Developer Experience Portal for Documentation and CodeGen as a SDK Generator. Support for both versions of OpenAPI is there. The list has been updated accordingly.