### PR TITLE
Add openapi3-generator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -120,7 +120,18 @@
   description: Generate Slate/Shins markdown from OpenAPI 2.0/3.0.x
   v2: true
   v3: true
-
+  
+- name: openapi3-generator
+  category:
+    - documentation
+    - code-generators
+  link: https://github.com/fmvilas/openapi3-generator
+  github: https://github.com/fmvilas/openapi3-generator
+  language: Node.js
+  description: Use your API OpenAPI 3 definition to generate code, documentation, and literally anything you need.
+  v2: false
+  v3: true
+  
 
 - name: generator-openapi-repo
   category: code-generators


### PR DESCRIPTION
Hey! I recently launched openapi3-generator, a tool to generate anything (docs, code, etc.) from an OpenAPI 3. I say "anything" because basically what it does is just pass an OpenAPI 3 document to a Handlebars template, and you can create your own templates.

https://github.com/fmvilas/openapi3-generator