### PR TITLE
Add Apiary in Editors

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -248,6 +248,17 @@
   v2: true
   v3: true
 
+- name: Apiary
+  category: editors
+  language: SaaS
+  github: https://github.com/apiaryio
+  link: https://apiary.io/
+  description: |
+    API design, documentation and test platform to improve collaboration, standardize development workflow and centralize their
+    API discovery and consumption.
+  v2: true
+  v3_progress_link: https://github.com/apiaryio/fury-adapter-swagger/issues/131
+
 # Mock Servers
 - name: Prism
   category: mock


### PR DESCRIPTION
I discovered your repo a few days ago thanks to a teammate, it's a great idea but even if I knew most of them, I didn't found any of the tools I used :(
So here is one of them, Apiary, which I prefer to SwaggerHub for its better overall UI and UX and, above all, the ability to see the results of the implementation tests.