### PR TITLE
Update OAS version and link

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         <div>
           <h2 class="font-sans font-light pt-2 pb-2">Current OpenAPI Version</h2>
           <blockquote class="blockquote">
-            <p class="lead font-serif">3.0.1 - <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md">Link to the specification</a></p>
+            <p class="lead font-serif">3.0.2 - <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md">Link to the specification</a></p>
           </blockquote>
         </div>
 


### PR DESCRIPTION
I was on the page looking up a tool and notice the OAS version was behind

Changed 3.0.1 -> 3.0.2