### PR TITLE
Add v2 support to Gnostic

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -21,6 +21,7 @@
   github: https://github.com/googleapis/gnostic
   language: Go
   description: Compile OpenAPI descriptions into equivalent Protocol Buffer representations
+  v2: true
   v3: true
 
 - name: swagger2openapi


### PR DESCRIPTION
Minor fix: Google Gnostic does indeed support v2 (sorry if it wasn't added for some other reason, just close this).

- https://github.com/googleapis/gnostic
- https://twitter.com/no_d_here/status/1055304603162439680