### PR TITLE
Add dorthu/openapi3 to parser tools

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -535,6 +535,14 @@
   v2: false
   v3: true
 
+- name: openapi3
+  category: parsers
+  github: https://github.com/Dorthu/openapi3
+  language: Python
+  description: "A Python OpenAPI 3 Specification client and validator for Python 3."
+  v2: false
+  v3: true
+
 # [oai-ts-core](https://github.com/Apicurio/oai-ts-core)|typescript|Core typescript library to read and manipulate OpenAPI specification definitions|
 # [openapi4j](https://github.com/gskorupa/openapi4j)|Java|
 # [openapi-parser](https://github.com/networknt/openapi-parser) | Java | Based on KaiZen generated code but removed Javaparser-core, guava, commons-cli, commons-io, javax.mail and guice for microservices | https://doc.networknt.com/getting-started/light-rest-4j/

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -539,7 +539,7 @@
   category: parsers
   github: https://github.com/Dorthu/openapi3
   language: Python
-  description: "A Python OpenAPI 3 Specification client and validator for Python 3."
+  description: "An OpenAPI 3 Specification client, and validator, covering both schema validation and limited data validation for Python 3."
   v2: false
   v3: true
 


### PR DESCRIPTION
Requested by @philsturgeon in Slack:
https://apisyouwonthate.slack.com/archives/C6EEULS87/p1541185349034200?thread_ts=1541086002.032400&cid=C6EEULS87

https://github.com/Dorthu/openapi3

Here are some snippets of the functionality from the README:

> A Python OpenAPI 3 Specification client and validator for Python 3.
> ...
> This module can be run against a spec file to validate it like so:
> ```
> python3 -m openapi /path/to/spec
> ```
> ...
> This library also functions as an interactive client for arbitrary OpenAPI 3 specs. For example, using Linode's OpenAPI 3 Specification for reference:
> ...

@Dorthu