### PR TITLE
Added Generate OAS

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -750,7 +750,7 @@
   
 - name: Generate OAS
   category: miscellaneous
-  language: JavaScript, Java, Python, Ruby, Go, Typescript
+  language: Self-hosted/SaaS
   link: https://generateoas.com/
   github: https://github.com/opticdev/optic
   description: Generate accurate OAS Specs from your API tests

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -747,6 +747,15 @@
   description: Generate OAS files from code comments and easily host them ($ npm install oas -g)
   v2: true
   v3: true
+  
+- name: Generate OAS
+  category: miscellaneous
+  language: JavaScript, Java, Python, Ruby, Go, Typescript
+  link: https://generateoas.com/
+  github: https://github.com/opticdev/optic
+  description: Generate accurate OAS Specs from your API tests
+  v2: false
+  v3: true
 
 # Testing
 - name: hikaku


### PR DESCRIPTION
Generate OAS Specs by running your API Tests. The traffic from the tests is used to generate accurate specs. 