### PR TITLE
Added Mojolicious::Plugin::OpenApi under server category

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -444,6 +444,17 @@
   v2: true
   v3: true
 
+- name: Mojolicious::Plugin::OpenApi
+  category: server
+  language: Perl
+  link: https://metacpan.org/pod/Mojolicious::Plugin::OpenAPI
+  github: https://github.com/jhthorsen/mojolicious-plugin-openapi
+  description: |
+    Mojolicious::Plugin::OpenAPI is a plugin for Mojolicious framework that add routes and input/output validation to your Mojolicious application based on a OpenAPI (Swagger) specification.
+    Currently v2 is very well supported, while v3 should be considered EXPERIMENTAL.
+  v2: true
+  v3: true
+
 # Schema Validators
 
 - name: Speccy


### PR DESCRIPTION
Mojolicious::Plugin::OpenApi is a great tool that allows you to use Swagger and OpenAPI with a Mojolicious Web Framework as an input for your server routes, also it provides automatic validation for requests and responses (optional) and generate documentation in html and json formats.

In my opinion, it's the best such tool in Perl world. So it would be nice to mention it in your project.
