### PR TITLE
Add Fakeit to mock server tools

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -386,6 +386,15 @@
   v2: true
   v3: true
 
+- name: Fakeit
+  category: mock
+  language: cli / Docker
+  link: https://github.com/justinfeng/fakeit
+  github: https://github.com/justinfeng/fakeit
+  description: Create mock server from OpenAPI 3 specification with random response generation and request validation.
+  v2: false
+  v3: true
+
 # Server implementations
 
 - name: Vert.x Web Api Contract


### PR DESCRIPTION
[Fakeit](https://github.com/justinfeng/fakeit) is a command line / docker tool to create mock server from Openapi specification

Description
* Randomly generated response
* Request validation
* Load specification from local or remote
* Support specification in yaml or json format