### PR TITLE
remove chai-openapi-res-validator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -836,14 +836,6 @@
   v3: true
 
 # Testing
-- name: Chai OpenAPI Response Validator
-  category: testing
-  language: Node.js
-  github: https://github.com/openapi-chai/chai-openapi-response-validator
-  description: Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec.
-  v2: true
-  v3: true
-
 - name: hikaku
   category: testing
   language: Kotlin


### PR DESCRIPTION
Unfortunately after adding this package (https://github.com/apisyouwonthate/openapi.tools/pull/112) I discovered that it was not ready for release, and so have taken it down for the time being. Hopefully we can re-release a new and improved version soon!