### PR TITLE
Add openapi-cli-tool

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -234,6 +234,15 @@
   v2: true
   v3: true
 
+- name: openapi-cli-tool
+  category: documentation
+  link: https://pypi.org/project/openapi-cli-tool/
+  github: https://github.com/hakopako/openapi-cli-tool
+  language: Python
+  description: Can list up defined API paths and bundle multi-file into one. Supports multiple file extensions.
+  v2: false
+  v3: true
+
 # [io-docs](https://github.com/mikeralphson/iodocs)|Node.js|fork of Mashery IO-docs with OpenAPI 2/3 support|http://io-docs.herokuapp.com/
 # [lincoln](https://github.com/temando/open-api-renderer)|React.js|A React renderer for Open API v3|https://temando.github.io/open-api-renderer/demo/?url=https://temando.github.io/open-api-renderer/petstore-open-api-v3.0.0-RC2.json
 

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -234,15 +234,6 @@
   v2: true
   v3: true
 
-- name: openapi-cli-tool
-  category: documentation
-  link: https://pypi.org/project/openapi-cli-tool/
-  github: https://github.com/hakopako/openapi-cli-tool
-  language: Python
-  description: Can list up defined API paths and bundle multi-file into one. Supports multiple file extensions.
-  v2: false
-  v3: true
-
 # [io-docs](https://github.com/mikeralphson/iodocs)|Node.js|fork of Mashery IO-docs with OpenAPI 2/3 support|http://io-docs.herokuapp.com/
 # [lincoln](https://github.com/temando/open-api-renderer)|React.js|A React renderer for Open API v3|https://temando.github.io/open-api-renderer/demo/?url=https://temando.github.io/open-api-renderer/petstore-open-api-v3.0.0-RC2.json
 
@@ -842,6 +833,15 @@
   github: https://github.com/readmeio/oas
   description: Generate OAS files from code comments and easily host them ($ npm install oas -g)
   v2: true
+  v3: true
+  
+- name: openapi-cli-tool
+  category: miscellaneous
+  link: https://pypi.org/project/openapi-cli-tool/
+  github: https://github.com/hakopako/openapi-cli-tool
+  language: Python
+  description: Can list up defined API paths and bundle multi-file into one. Supports multiple file extensions.
+  v2: false
   v3: true
 
 # Testing


### PR DESCRIPTION
openapi-cli-tool is a collection of useful commands for working with OpenApi specifications. 

Description:

- Can list up defined API paths.
- Display an API specification which is resolved ($ref).
- Bundle multi-file into one (output to json|yaml|html).
- OAS interactive scaffolding.