### PR TITLE
Adding new Python tool that generates OpenAPI3.0 specs

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -241,6 +241,15 @@
   description: Bump generates elegant documentations and changelogs from your OpenAPI specifications. Git diff, for your API.
   v2: true
   v3: true
+  
+- name: Python OpenAPI Generator
+  category: code-generators
+  link: https://github.com/wael34218/python_openapi_generator
+  language: Python
+  github: https://github.com/wael34218/python_openapi_generator
+  description: This library facilitates creating OpenAPI (Swagger) document for Python projects.
+  v2: false
+  v3: true
 
 # [io-docs](https://github.com/mikeralphson/iodocs)|Node.js|fork of Mashery IO-docs with OpenAPI 2/3 support|http://io-docs.herokuapp.com/
 # [lincoln](https://github.com/temando/open-api-renderer)|React.js|A React renderer for Open API v3|https://temando.github.io/open-api-renderer/demo/?url=https://temando.github.io/open-api-renderer/petstore-open-api-v3.0.0-RC2.json


### PR DESCRIPTION
A python developer can generate OpenAPI 3.0 spec file easily using this library.

It consumes a `response` object and converts it into OpenAPI spec. A developer can create the entire documentation of the entire app within one reproducible script.