### PR TITLE
add Chai OpenAPI Response Validator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -892,6 +892,14 @@
   v3: true
 
 # Testing
+- name: Chai OpenAPI Response Validator
+  category: testing
+  language: Node.js
+  github: https://github.com/RuntimeTools/chai-openapi-response-validator
+  description: Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec.
+  v2: true
+  v3: true
+
 - name: hikaku
   category: testing
   language: Kotlin


### PR DESCRIPTION
*(This was previously merged in https://github.com/apisyouwonthate/openapi.tools/pull/112 and then taken out in https://github.com/apisyouwonthate/openapi.tools/pull/116 because I discovered that I should have released it in a new repo instead. I've done that now, and also improved this version in the meantime).*

[Chai OpenAPI Response Validator](https://github.com/RuntimeTools/chai-openapi-response-validator) is a Chai plugin providing support for easily asserting that HTTP responses satisfy an OpenAPI spec, e.g.:
```
expect(res).to.have.status(200).and.satisfyApiSpec
```

Helps to do Contract Testing with OpenAPI in Node.js. (Related to your discussion on contract testing with JSON schema https://apisyouwonthate.com/blog/writing-documentation-via-contract-testing) 

Feedback appreciated! :)
