### PR TITLE
adds tsoa to the list of server implementations

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -337,7 +337,7 @@
   v3: true
 
 - name: Stoplight Studio
-  category: 
+  category:
   - gui-editors
   - text-editor
   language: Desktop / SaaS
@@ -420,6 +420,15 @@
   v3: true
 
 # Server implementations
+
+- name: tsoa
+  category: server
+  language: TypeScript
+  link: https://github.com/lukeautry/tsoa
+  github: https://github.com/lukeautry/tsoa
+  description: Create swagger/OpenAPI docs and get free runtime validation for your Koa, Express, Hapi (and more) services
+  v2: true
+  v3: true
 
 - name: Vert.x Web Api Contract
   category: server

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -422,11 +422,13 @@
 # Server implementations
 
 - name: tsoa
-  category: server
+  category:
+    - server
+    - data-validation
   language: TypeScript
   link: https://github.com/lukeautry/tsoa
   github: https://github.com/lukeautry/tsoa
-  description: Create swagger/OpenAPI docs and get free runtime validation for your Koa, Express, Hapi (and more) services
+  description: Creates OpenAPI docs and provides free runtime validation for your Koa, Express, Hapi (and more) services
   v2: true
   v3: true
 


### PR DESCRIPTION
At the moment, [`tsoa`](https://github.com/lukeautry/tsoa) is the most used TypeScript library for OpenAPI and Swagger generation + validation (based off of metrics from npmtrends.com). I noticed that it is isn't available in https://https://openapi.tools/ so I've created this PR to add it. I apologize if I was supposed to create an issue first, but I didn't see a CONTRIBUTING.md file so I wasn't sure what the process was. Hopefully you can accept this PR. Thank you. :)