### PR TITLE
Add nexmo-oas-renderer gem to documentation section

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -125,6 +125,13 @@
   v2: true
   v3: true
 
+- name: Nexmo OAS Renderer
+  category: documentation
+  github: https://github.com/Nexmo/nexmo-oas-renderer
+  language: Ruby
+  description: Ruby OpenAPI docs rendering, use standalone or add to your Rails app
+  v3: true
+
 - name: openapi-viewer
   category: documentation
   link: https://koumoul.com/openapi-viewer/


### PR DESCRIPTION
We knocked our documentation renderer into a shape where it's useful by itself so that others can use it, either alone or in a Rails app. Adding it to the list in case anyone comes here looking for such a thing.