### PR TITLE
Add oas3-api-snippet-enricher mention

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -154,7 +154,7 @@
   language: JavaScript
   github: https://github.com/cdwv/oas3-api-snippet-enricher/
   link: https://github.com/cdwv/oas3-api-snippet-enricher/
-  description: Enrich your OpenAPI 3.0 JSON with code samples
+  description: Enrich your existing description documents with generated code samples
   v3: true
   
 - name: widdershins

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -149,6 +149,14 @@
   v2: true
   v3: true
 
+- name: oas3-api-snippet-enricher
+  category: documentation
+  language: JavaScript
+  github: https://github.com/cdwv/oas3-api-snippet-enricher/
+  link: https://github.com/cdwv/oas3-api-snippet-enricher/
+  description: Enrich your OpenAPI 3.0 JSON with code samples
+  v3: true
+  
 - name: widdershins
   category: documentation
   link: https://mermade.github.io/shins


### PR DESCRIPTION
Add oas3-api-snippet-enricher to list of documentation tools. The tool automatically includes code samples for all methods in the API.