### PR TITLE
swagman mock and convert

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -476,6 +476,18 @@
   v2: true
   v3: true
 
+- name: SwagmanMock
+  category:
+    - mock
+    - converters
+  language: Python,
+  link: https://github.com/codeasashu/swagmanmock
+  github: https://github.com/codeasashu/swagmanmock
+  description: |
+     A Postman to openapi spec converter with mocking facilities.
+  v2: false
+  v3: true
+
 # Server implementations
 
 - name: tsoa

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -476,13 +476,13 @@
   v2: true
   v3: true
 
-- name: SwagmanMock
+- name: Openman
   category:
     - mock
     - converters
   language: Python
-  link: https://github.com/codeasashu/swagmanmock
-  github: https://github.com/codeasashu/swagmanmock
+  link: https://github.com/codeasashu/openman
+  github: https://github.com/codeasashu/openman
   description: |
      A Postman to openapi spec converter with mocking facilities.
   v2: false

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -480,7 +480,7 @@
   category:
     - mock
     - converters
-  language: Python,
+  language: Python
   link: https://github.com/codeasashu/swagmanmock
   github: https://github.com/codeasashu/swagmanmock
   description: |


### PR DESCRIPTION
Swagmanmock provides a python tool (and module) to convert postman collection to openapi spec. Additionally, this tool also mocks the spec using postman examples and documents them