### PR TITLE
Add Ruby openapi3_parser gem

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -925,6 +925,14 @@
     validation and limited data validation for Python 3.
   v2: false
   v3: true
+  
+- name: openapi3_parser
+  category: parsers
+  github: https://github.com/kevindew/openapi3_parser
+  language: Ruby
+  description: A Ruby implementation of parser and validator for the OpenAPI 3 Specification.
+  v2: false
+  v3: true
 
 - name: APIMatic CodeGen
   category: sdk


### PR DESCRIPTION
Hello :wave:, I'm adding a link to the OpenAPI 3 Parser I maintain. It's a long running project however I didn't know about this resource before.

I've also got a blog post that might be of interest but didn't seem to fit any categories: https://kevindew.me/post/188611423231/how-to-write-an-openapi-3-parser

Thanks