### PR TITLE
Add spireui.com

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -403,6 +403,14 @@
   v2: true
   v3: true
 
+- name: SpireUI
+  category: gui-editors
+  language: React (Typescript)
+  link: https://spireui.com
+  description: Instantly generate a web app from your OpenAPI specification.
+  v2: false
+  v3: true
+
 # Learning 
 - name: Optic
   category: learning


### PR DESCRIPTION
SpireUI is a web app I have created to easily create a web app for REST APIs. It uses your OpenAPI spec to generate a basic web app which you can then further customize. I think it would be a useful addition to this page.

It doesn't exactly fit your definition of a GUI Editor (it doesn't actually allow you to edit you OpenAPI spec). But that seemed to be the closest category. Let me know if you think there is a more appropriate category. Thanks!