### PR TITLE
Add Flotiq mention to SDK, GUI editors and misc

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1079,6 +1079,15 @@
   v2: false
   v3: true
 
+- name: Flotiq - headless CMS with OpenAPI support
+  category:
+  - sdk
+  - gui-editors
+  - miscellaneous
+  link: https://flotiq.com
+  description: Visually define your Content Types, Flotiq automatically generates your own OpenAPI v3 compatible endpoints, SDKs and Postman collections.
+  v3: true
+  
 - name: Chai OpenAPI Response Validator
   category: testing
   language: Node.js


### PR DESCRIPTION
Hi All, I'd like to submit our headless Content Management System - [Flotiq](https://flotiq.com) - to the list. 

The tool provides:

1. a GUI editor for defining Content Types, which are based on OpenAPI primitives
<img src="https://user-images.githubusercontent.com/3079734/74236751-2f61c080-4cd2-11ea-99c1-f0057c92aeea.png" width="400"/>

<img src="https://user-images.githubusercontent.com/3079734/74236731-253fc200-4cd2-11ea-9f3b-77ca91cdc780.png" width="400"/>

2. an automatically updated API-doc, with built-in code samples, generated after every change to the Content Types
![image](https://user-images.githubusercontent.com/3079734/74236557-c417ee80-4cd1-11ea-8091-60c227858f8f.png)
3. Downloadable SDKs and Postman collection, regenerated automatically with every change to the Content types

<img src="https://user-images.githubusercontent.com/3079734/74236772-3e487300-4cd2-11ea-9f5e-2b75b6ff7b33.png" width="400"/>

Please let me know if there's anything you'd like me to amend in this PR.