### PR TITLE
Add tool: oa-client

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1357,3 +1357,14 @@
   description: Automatically generate OpenAPI 3.0 Spec by using network requests captured in one or more HAR files
   v2: false
   v3: true
+
+- name: oa-client
+  category:
+    - miscellaneous
+    - sdk
+  language: TypeScript
+  link: https://github.com/ninofiliu/oa-client
+  github: https://github.com/ninofiliu/oa-client
+  description: Flexible client helper for making and validating calls to OpenAPI backends. For Node and the browser. Runtime lib - no need for code generation!
+  v2: false
+  v3: true


### PR DESCRIPTION
The goal of this library is to create *at runtime* a client helper to make and validate calls to an OpenAPIv3-compliant backend. It is used by [ToucanToco](https://toucantoco.com), in [a POC for the "contract-driven API pattern"](https://github.com/ninofiliu/contract-driven-api), and also in my upcoming personal website. Would be awesome to appear in openapi.tools!

Since it's a runtime library, it *does not* generate code, so it's not really an SDK generator, eventhough the usage of it is *very* close (but a bit better imho, lol), which is why I put the category halfway between sdk and miscellaneous.

Thanks for reviewing this! :bow: 