### PR TITLE
update GitHub link to chai-openapi-response-validator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1213,7 +1213,7 @@
 - name: Chai OpenAPI Response Validator
   category: testing
   language: Node.js
-  github: https://github.com/RuntimeTools/chai-openapi-response-validator
+  github: https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/chai-openapi-response-validator
   description:
     Simple Chai support for asserting that HTTP responses satisfy an OpenAPI
     spec.


### PR DESCRIPTION
[Chai OpenAPI Response Validator](https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/chai-openapi-response-validator) was added in https://github.com/apisyouwonthate/openapi.tools/pull/130. 

This PR updates the GitHub link, which has changed because I've since converted that repo to a monorepo (to group it with its sister package [`jest-openapi`](https://github.com/apisyouwonthate/openapi.tools/pull/193))

Thanks!