### PR TITLE
add jest-openapi

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1220,6 +1220,16 @@
   v2: true
   v3: true
 
+- name: jest-openapi
+  category: testing
+  language: Node.js
+  github: https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/jest-openapi
+  description:
+    Additional Jest matchers for asserting that HTTP responses satisfy an OpenAPI
+    spec.
+  v2: true
+  v3: true
+
 - name: hikaku
   category: testing
   language: Kotlin


### PR DESCRIPTION
[jest-openapi](https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/jest-openapi) is a sister package to [Chai OpenAPI Response Validator](https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/chai-openapi-response-validator), which you already have listed here. 

jest-openapi provides Jest matchers to easily assert that HTTP responses satisfy an OpenAPI spec, e.g.:
```
expect(responseObject).toSatisfyApiSpec();
```

Helps to do Contract Testing with OpenAPI in Node.js.

Feedback appreciated! :)