### PR TITLE
feat: add Restish

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1406,3 +1406,14 @@
   description: Flexible client helper for making and validating calls to OpenAPI backends. For Node and the browser. Runtime lib - no need for code generation!
   v2: false
   v3: true
+
+- name: Restish
+  category:
+    - documentation
+    - miscellaneous
+    - testing
+  language: CLI / Go
+  link: https://rest.sh/
+  github: https://github.com/danielgtaylor/restish
+  description: A CLI for REST-ish APIs with HTTP/2, built-in auth, content negotiation, caching, and more that understands and can discover OpenAPI descriptions.
+  v3: true


### PR DESCRIPTION
This adds the [Restish](https://rest.sh/) CLI tool, which didn't fit perfectly in any single category so I put it into several:

- Documentation: It will read OpenAPI and generate useful `--help` which includes the request/response schemas & descriptions as well as generated example commands you can make against the API.
- Miscellaneous: best place for a generic CLI tool?
- Testing: it can be used to make authenticated test requests against the API and filter the responses to specific fields you want to test.