### PR TITLE
Add OpenAPI HttpFoundation Testing

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1594,3 +1594,11 @@
   description:
     Validates Request and Response using Symfony Framework
   v3: true
+
+- name: OpenAPI HttpFoundation Testing
+  category: data-validators
+  language: PHP
+  description: Strengthen your API tests by validating HttpFoundation responses against OpenAPI definitions
+  github: https://github.com/osteel/openapi-httpfoundation-testing
+  v2: false
+  v3: true


### PR DESCRIPTION
Hey there,

It's a package to validate HttpFoundation (Symfony, Laravel, Drupal...) responses against OpenAPI definitions, meant to be used with integration tests.

I think `data-validators` is the right category here, but I might  be wrong.

Let me know what you think!

Cheers,

Yannick