### PR TITLE
Add openapi-filter

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1052,7 +1052,7 @@
   github: https://github.com/Mermade/openapi-filter
   language: Node.js
   description:
-    OpenAPI 2.0 and 3.0 filter utility. A CLI/module to filter out internal/private paths, operations, parameters, schemas etc from OpenAPI/Swagger/AsyncAPI definitions.
+    OpenAPI 2.0 and 3.0 filter utility. A CLI/module to filter out internal/private paths, operations, parameters, schemas etc from OpenAPI v1/OpenAPI v2/AsyncAPI definitions.
     Simply flag any OpenAPI object within the definition with an `x-internal` specification extension or target a OpenAPI property (tags, methods, OperationId), and it will be removed from the output.
   v2: true
   v3: true

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1052,7 +1052,7 @@
   github: https://github.com/Mermade/openapi-filter
   language: Node.js
   description:
-    Swagger/OpenAPI 2.0 and 3.0 filter utility. A CLI/module to filter out internal/private paths, operations, parameters, schemas etc from OpenAPI/Swagger/AsyncAPI definitions.
+    OpenAPI 2.0 and 3.0 filter utility. A CLI/module to filter out internal/private paths, operations, parameters, schemas etc from OpenAPI/Swagger/AsyncAPI definitions.
     Simply flag any OpenAPI object within the definition with an `x-internal` specification extension or target a OpenAPI property (tags, methods, OperationId), and it will be removed from the output.
   v2: true
   v3: true

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1047,6 +1047,16 @@
   v2: true
   v3: true
 
+- name: openapi-filter
+  category: parsers
+  github: https://github.com/Mermade/openapi-filter
+  language: Node.js
+  description:
+    Swagger/OpenAPI 2.0 and 3.0 filter utility. A CLI/module to filter out internal/private paths, operations, parameters, schemas etc from OpenAPI/Swagger/AsyncAPI definitions.
+    Simply flag any OpenAPI object within the definition with an `x-internal` specification extension or target a OpenAPI property (tags, methods, OperationId), and it will be removed from the output.
+  v2: true
+  v3: true
+
 - name: KaiZen OpenAPI Parser
   github: https://github.com/RepreZen/KaiZen-OpenApi-Parser
   owner: RepreZen


### PR DESCRIPTION
Addition of a handy CLI/module to strip/filter OpenAPI specs via CLI/module.
Most common use-case is to remove internal/private paths.
Very practical for CI/CD pipeline operations.