### PR TITLE
Update GitHub links for 2 testing tools

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1340,7 +1340,7 @@
 - name: Chai OpenAPI Response Validator
   category: testing
   language: Node.js
-  github: https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/chai-openapi-response-validator
+  github: https://github.com/openapi-library/OpenAPIValidators/tree/master/packages/chai-openapi-response-validator
   description:
     Simple Chai support for asserting that HTTP responses satisfy an OpenAPI
     spec.
@@ -1350,7 +1350,7 @@
 - name: jest-openapi
   category: testing
   language: Node.js
-  github: https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/jest-openapi
+  github: https://github.com/openapi-library/OpenAPIValidators/tree/master/packages/jest-openapi
   description:
     Additional Jest matchers for asserting that HTTP responses satisfy an OpenAPI
     spec.


### PR DESCRIPTION
I maintain [jest-openapi](https://github.com/openapi-library/OpenAPIValidators/tree/master/packages/jest-openapi) and [chai-openapi-response-validator](https://github.com/openapi-library/OpenAPIValidators/tree/master/packages/chai-openapi-response-validator) and have migrated them to a new GitHub organisation

Thanks!