### PR TITLE
Add openapi-data-mocker PHP package

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -697,6 +697,17 @@
   v2: true
   v3: true
 
+- name: openapi-data-mocker
+  category: mock
+  language: PHP
+  github: https://github.com/ybelenko/openapi-data-mocker
+  description: >
+    Tiny library to generate basic OpenAPI Data Types. Consider it as extended Faker
+    package. First version able to mock most of the data formats. It doesn't support
+    polymorphism yet, but work in progress. May be useful for writing custom unit tests.
+  v2: false
+  v3: true
+
 - name: tsoa
   category:
     - server


### PR DESCRIPTION
Hey, there!

My package is very tiny right now comparing to other PHP solutions, but still might be useful. I have another two packages related to OAS development, but they makes no sense if you won't approve this core package.

[openapi-data-mocker](https://github.com/ybelenko/openapi-data-mocker) was originally developed as part of [OpenAPI Generator - Server Slim 4](https://openapi-generator.tech/docs/generators/php-slim4) codegen. Then I realized that this tiny library maybe more useful as standalone package.

The major disadvantage that it cannot parse description document. So it expects deserialized parts description document in most of the methods, but I'm going to fix it in next versions.
The second issue is that it needs generated PHP models for referenced schemas.
Both confusing features are legacy from OpenAPI Generator usage.

Anyway, [documented usage example](https://github.com/ybelenko/openapi-data-mocker#usage-example) demonstrates what this library is capable of.