### PR TITLE
Adding 3.1 support for Microcks + testing category

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -624,16 +624,17 @@
   v3: true
 
 - name: Microcks
-  category: mock
+  category: mock,testing
   language: Self-hosted / SaaS
-  link: https://microcks.github.io
+  link: https://microcks.io
   github: https://github.com/microcks/microcks
   description:
-    Mocking and testing platform for API and microservices. Turn your OAI
-    contract examples into ready to use mocks. Use examples to test and validate implementations
-    according schema elements.
+    Kubernetes native tool for API Mocking and Testing. Turn your OAI contract examples
+    into ready to use mocks. Use examples to test and validate implementations
+    according spec and schema elements.
   v2: true
   v3: true
+  v3_1: true
 
 - name: API Sprout
   category: mock


### PR DESCRIPTION
Microcks supports importing OpenAPI 3.1 specifications for creating mocks and validating endpoints.