### PR TITLE
Add oauth2_as_oas3_components repo

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1763,3 +1763,12 @@
   description: Collaboration platform for product and API documentation
   v2: true
   v3: true
+
+- name: OAuth2 as OpenAPI Spec 3.0 components
+  category: miscellaneous
+  language: Any
+  github: https://github.com/ybelenko/oauth2_as_oas3_components
+  description:
+    OAuth2 token endpoint described with OAS3 schema. All grants documented. Can be installed as NPM or Composer package.
+  v2: false
+  v3: true


### PR DESCRIPTION
I've spent a few days of documenting OAuth2 token endpoints with OAS3. Hope somebody might find it useful.