### PR TITLE
add openapi2postman

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1836,3 +1836,15 @@
   description:
     A Perl library which validates request/response according to an OpenAPI specification
   v3: true
+  
+- name: openapi2postman
+  category: data-validators
+  language: nodejs
+  link: https://github.com/apiaddicts/openapi2postman
+  github: https://github.com/apiaddicts/openapi2postman
+  description:
+    A postman collection generator to test:
+    - create one collection for environment and one file enviroment
+    - tests responses format
+    - test all http response codes
+  v3: true

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1836,9 +1836,9 @@
   description:
     A Perl library which validates request/response according to an OpenAPI specification
   v3: true
-  
+
 - name: openapi2postman
-  category: data-validators
+  category: Testing
   language: nodejs
   link: https://github.com/apiaddicts/openapi2postman
   github: https://github.com/apiaddicts/openapi2postman

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1848,3 +1848,24 @@
     - tests responses format
     - test all http response codes
   v3: true
+- name: openapi2postman
+  category: Testing
+  language: nodejs
+  link: https://github.com/apiaddicts/openapi2postman
+  github: https://github.com/apiaddicts/openapi2postman
+  description:
+    A postman collection generator to test:
+    - create one collection for environment and one file enviroment
+    - tests responses format
+    - test all http response codes
+  v3: true
+- name: apigen
+  category: Auto Generators
+  language: springboot
+  link: https://github.com/apiaddicts/apigen
+  github: https://github.com/apiaddicts/apigen
+  description:
+    Apigen allow generate springboot archetipe using openapi file as mapping tool between the openapi definition and the database.
+  v3: true
+
+  


### PR DESCRIPTION
openapi2postman is a opensource test tool generator that generate all test cases in a postman collection using the openapi definition file. Also, allow:
- Generate one collection for environment
- Validate the output with the openapi schema
- Tests all http code responses
- Tests all required attributes
