### PR TITLE
OpenAPI 3.1 supported with openapi-backend

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -787,6 +787,7 @@
   description: Build, Validate, Route, and Mock using OpenAPI specification. Framework-agnostic
   v2: false
   v3: true
+  v3_1: true
 
 - name: OpenAPI Enforcer Middleware
   category: server


### PR DESCRIPTION
OAS 3.1 support added to openapi-backend from 4.2.0

Issue tracking this feature: https://github.com/anttiviljami/openapi-backend/issues/158