### PR TITLE
Update RapiDoc: supports OpenAPI 3.1

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -249,6 +249,7 @@
   language: Custom Element
   v2: true
   v3: true
+  v3_1: true
 
 - name: RapiPdf
   category: documentation


### PR DESCRIPTION
Since RapiDoc [v8.4.9](https://github.com/mrin9/RapiDoc/releases/tag/8.4.9).