### PR TITLE
data: Bump.sh has support for OAS 3.1 since the beginning of 2021

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -356,6 +356,7 @@
     specifications. Git diff, for your API.
   v2: true
   v3: true
+  v3_1: true
 
 - name: Python OpenAPI Generator
   category: code-generators


### PR DESCRIPTION
Bump supports most of the new features of OAS 3.1 (cf
https://bump.sh/blog/changes-in-openapi-3-1)