### PR TITLE
fix: Removed duplicate key from openapi-data-validator metadata

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -953,7 +953,6 @@
   language: Node.js/ Javascript
   description: "Validate API requests against an OpenAPI schema. Lightweight, focused, and integrates with any framework"
   link: https://github.com/Rhosys/openapi-data-validator.js/blob/main/README.md
-  github: https://github.com/Rhosys/openapi-data-validator.js
   v2: false
   v3: true
 


### PR DESCRIPTION
Spotted a duplicate key in `_data/tools.yml` when doing some work to discover tooling across the ecosystem.

Removed in order to fix and allow graceful parsing of the data therein.