### PR TITLE
fix: Removed duplicate github key from Rhosys/openapi-data-validator.js

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -953,7 +953,6 @@
   language: Node.js/ Javascript
   description: "Validate API requests against an OpenAPI schema. Lightweight, focused, and integrates with any framework"
   link: https://github.com/Rhosys/openapi-data-validator.js/blob/main/README.md
-  github: https://github.com/Rhosys/openapi-data-validator.js
   v2: false
   v3: true
 


### PR DESCRIPTION
Removed duplicate key for Rhosys/openapi-data-validator.js to allow for easy parsing of data to pull into OpenAPI tooling repository