### PR TITLE
Added Redocly OpenAPI VS code extension to Text Editors

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -469,6 +469,17 @@
   v2: true
   v3: true
 
+- name: VSCode/Redocly OpenAPI
+  category: text-editors
+  language: Node.js
+  link: https://marketplace.visualstudio.com/items?itemName=Redocly.openapi-vs-code
+  github: https://github.com/Redocly/redocly-vs-code
+  description:
+    Redocly OpenAPI is a Visual Studio Code extension that helps you write, validate, preview, and maintain your OpenAPI documents.
+  v2: true
+  v3: true
+  v3_1: true
+
 - name: RepreZen API Studio
   category: gui-editors
   language: Java


### PR DESCRIPTION
Added Redocly OpenAPI VS code extension to Text Editors

marketplace: https://marketplace.visualstudio.com/items?itemName=Redocly.openapi-vs-code
github: https://github.com/Redocly/redocly-vs-code
  