### PR TITLE
update to show OAS 3.1 support in mayhem for api

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1857,6 +1857,7 @@
   description: Probe your REST API with an infinite stream of test cases generated automatically from your OpenAPI specification.
   v2: true
   v3: true
+  v3_1: true
 
 - name: JSONSchema::Validator
   category: data-validators


### PR DESCRIPTION
Mayhem for API added OAS3.1 support in version 2.10.0. Release notes: https://mayhem4api.forallsecure.com/docs/release-notes.html