### PR TITLE
Revert "openapi-explorer does not support OpenAPI v3.1 (#335)"

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -192,7 +192,7 @@
   language: Javascript/Custom Element
   v2: true
   v3: true
-  v3_1: false
+  v3_1: true
 
 - name: openapi-viewer
   category: documentation


### PR DESCRIPTION
This reverts commit d158914abfd0631cd42326370defd1e2a2db42de. #335 rhosys/openapi-explorer#50