### PR TITLE
Added modern versin of har-to-openapi and changed language of openapi-contrib tools

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1561,7 +1561,7 @@
   
 - name: OpenAPI Schema to JSON Schema
   category: converters
-  language: JavaScript
+  language: TypeScript
   description: Due to the OpenAPI v3.0 and JSON Schema discrepancy, you can use this JS library to convert OpenAPI Schema objects to proper JSON Schema.
   link: https://www.npmjs.com/package/@openapi-contrib/openapi-schema-to-json-schema
   github: https://github.com/openapi-contrib/openapi-schema-to-json-schema
@@ -1569,7 +1569,7 @@
 
 - name: JSON Schema to OpenAPI Schema
   category: converters
-  language: JavaScript
+  language: TypeScript
   description: Due to the OpenAPI v3.0 and JSON Schema discrepancy, you can use this JS library to convert JSON Schema objects to OpenAPI Schema.
   link: https://www.npmjs.com/package/@openapi-contrib/json-schema-to-openapi-schema
   github: https://github.com/openapi-contrib/json-schema-to-openapi-schema
@@ -1610,6 +1610,14 @@
   language: TypeScript
   link: https://github.com/dcarr178/har2openapi
   github: https://github.com/dcarr178/har2openapi
+  description: Automatically generate OpenAPI 3.0 Spec by using network requests captured in one or more HAR files
+  v3: true
+
+- name: har-to-openapi
+  category: auto-generators
+  language: TypeScript
+  link: https://github.com/jonluca/har-to-openapi
+  github: https://github.com/jonluca/har-to-openapi
   description: Automatically generate OpenAPI 3.0 Spec by using network requests captured in one or more HAR files
   v3: true
 


### PR DESCRIPTION
I recently rewrote the json-schema-to-openapi and openapi-to-json-schema tools in typescript, so those should be natively supported, and I also published a much more mature and correct version of `har-to-openapi`. This adds both of those. 