### PR TITLE
Updated v3_1 for optic, added optic diff

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -6,6 +6,15 @@
   v3: true
   v3_1: false
 
+- name: optic diff
+  category: miscellaneous
+  language: Go
+  github: https://github.com/opticdev/optic
+  link: https://www.useoptic.com/docs/openapi-diff
+  description: Diff the effective API contract between any two versions of your OpenAPI spec. Exit 1 on breaking changes.  
+  v3: true
+  v3_1: true
+
 - name: CUE
   category: dsl
   language: CUE
@@ -579,9 +588,9 @@
   link: https://useoptic.com
   github: https://github.com/opticdev/optic
   description:
-    A proxy server that watches an API and helps you build an OpenAPI description
-    interactively.
+    Build your first OpenAPI Spec from traffic. Use Optic to patch the OpenAPI every time it detects new API behavior. 
   v3: true
+  v3_1: true
 
 - name: APIClarity
   category: learning

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -11,7 +11,7 @@
   language: Go
   github: https://github.com/opticdev/optic
   link: https://www.useoptic.com/docs/openapi-diff
-  description: Diff the effective API contract between any two versions of your OpenAPI spec. Exit 1 on breaking changes.  
+  description: Diff the effective API contract between any two versions of your OpenAPI description. Exit 1 on breaking changes.  
   v3: true
   v3_1: true
 
@@ -588,7 +588,7 @@
   link: https://useoptic.com
   github: https://github.com/opticdev/optic
   description:
-    Build your first OpenAPI Spec from traffic. Use Optic to patch the OpenAPI every time it detects new API behavior. 
+    Build your first OpenAPI description from traffic. Use Optic to patch the OpenAPI every time it detects new API behavior. 
   v3: true
   v3_1: true
 

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -582,7 +582,7 @@
   v3: true
 
 # Learning
-- name: Optic
+- name: optic
   category: learning
   language: cli
   link: https://useoptic.com


### PR DESCRIPTION
👋  we now support 3.1! We also released our own diff tool [`optic diff` ](https://www.useoptic.com/docs/openapi-diff) which is a seperate toolchain from the rest of Opitc. 

Let me know if there's anything I can do to make this clearer :)