### PR TITLE
Add readmeio/oas

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1,3 +1,13 @@
+- name: readmeio/swagger-inline
+  category: dsl
+  language: Javascript / CLI
+  description:
+    A language-agnostic tool for documenting your API right from your code, generating an OpenAPI Definition.
+  link: https://github.com/readmeio/swagger-inline
+  v2: true
+  v3: true
+  v3_1: false
+
 - name: oasdiff
   category: miscellaneous
   language: Go

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1,9 +1,9 @@
-- name: readmeio/swagger-inline
+- name: readmeio/oas
   category: dsl
-  language: Javascript / CLI
+  language: TypeScript / CLI
   description:
     A language-agnostic tool for documenting your API right from your code, generating an OpenAPI Definition.
-  link: https://github.com/readmeio/swagger-inline
+  link: https://github.com/readmeio/oas
   v2: true
   v3: true
   v3_1: false


### PR DESCRIPTION
I would like to add a tool from readme.io that now supports OpenAPI 3 according to https://github.com/readmeio/swagger-inline/issues/8 even though it does not mention it on [the website](https://openap.is).