### PR TITLE
Spelling mistake

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1555,7 +1555,7 @@
   category: security
   language: Rust
   description:
-    Based on OpenAPI specification, openapi-fuzzer provides random data as inputs to the API endpoins in order to find bugs.
+    Based on OpenAPI specification, openapi-fuzzer provides random data as inputs to the API endpoints in order to find bugs.
   link: https://github.com/matusf/openapi-fuzzer
   v3: true 
 


### PR DESCRIPTION
endpoints spelled as "endpoins"