### PR TITLE
Bump.sh description and branding update

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -364,13 +364,14 @@
   v3: true  
   v3_1: false
 
-- name: Bump
+- name: Bump.sh
   category: documentation
   link: https://bump.sh
   language: SaaS
+  github: https://github.com/bump-sh/cli
   description:
-    Bump generates elegant documentation and changelogs from your OpenAPI
-    specifications. Git diff, for your API.
+    Bump.sh generates elegant documentation and changelogs from your OpenAPI
+    specifications. Git diff, for your API. Integrates with CI and Slack.
   v2: true
   v3: true
   v3_1: true

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -366,7 +366,7 @@
 
 - name: Bump.sh
   category: documentation
-  link: https://bump.sh
+  link: https://bump.sh?utm_source=openapi_tools&utm_medium=referral&utm_campaign=openapi
   language: SaaS
   github: https://github.com/bump-sh/cli
   description:


### PR DESCRIPTION
* Added the ".sh" extension as per current branding normalization efforts
* Added GitHub link to Open Source CLI
* Updated description