### PR TITLE
Updated version support for openapi-to-postman tooling.

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1697,7 +1697,7 @@
   category: converters
   github: https://github.com/postmanlabs/openapi-to-postman
   language: JavaScript
-  description: "Convert OpenAPI 3.0 specs to the Postman Collection (v2) format"
+  description: "Convert OpenAPI and Swagger specs to the Postman Collection (v2) format"
   v2: true
   v3: true
   v3_1: true

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1698,7 +1698,9 @@
   github: https://github.com/postmanlabs/openapi-to-postman
   language: JavaScript
   description: "Convert OpenAPI 3.0 specs to the Postman Collection (v2) format"
+  v2: true
   v3: true
+  v3_1: true
   v3_link: true
 
 - name: openapi-format


### PR DESCRIPTION
As discussed over here: https://github.com/postmanlabs/openapi-to-postman/issues/499#issuecomment-1369204949, raising PR with v2 and v3.1 support marked as true.

