### PR TITLE
Adds sdk tool; Openapi Json Schema Generator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -359,9 +359,9 @@
   category:
     - code-generators
     - sdk
-  link: https://github.com/openapi-json-schema-tools/
+  link: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator
   language: Python
-  github: https://github.com/openapi-json-schema-tools/
+  github: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator
   description:
     A template-driven engine to generate API client code + documentation
     by parsing your OpenAPI Description

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -355,6 +355,22 @@
   v3: true
   v3_1_link: https://github.com/OpenAPITools/openapi-generator/issues/9083
 
+- name: OpenAPI JSON Schema Generator
+  category:
+    - code-generators
+    - sdk
+  link: https://github.com/openapi-json-schema-tools/
+  language: Java
+  github: https://github.com/openapi-json-schema-tools/
+  description:
+    A template-driven engine to generate documentation, API clients and
+    in different languages by parsing your OpenAPI Description (community-driven
+    fork of openapi-generator)
+  v2: false
+  v3: true
+  v3_1: false
+  v3_1_link: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/issues/131
+
 - name: Kiota Api Client Generator
   category:
     - code-generators

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -360,15 +360,13 @@
     - code-generators
     - sdk
   link: https://github.com/openapi-json-schema-tools/
-  language: Java
+  language: Python
   github: https://github.com/openapi-json-schema-tools/
   description:
-    A template-driven engine to generate documentation, API clients and
-    in different languages by parsing your OpenAPI Description (community-driven
-    fork of openapi-generator)
+    A template-driven engine to generate API client code + documentation
+    by parsing your OpenAPI Description
   v2: false
   v3: true
-  v3_1: false
   v3_1_link: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/issues/131
 
 - name: Kiota Api Client Generator


### PR DESCRIPTION
Adds sdk tool; Openapi Json Schema Generator

It generates python clients and is at https://github.com/openapi-json-schema-tools/openapi-json-schema-generator

This generator works with 3.0.0 to 3.0.3 spec documents and 3.1.0 featured are being worked on. 

Could this PR be reviewed to get it added?
Thank you! 