### PR TITLE
Add AppMap Automated OpenAPI Generator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2201,3 +2201,13 @@
   link: https://github.com/criteo/openapi-comparator
   description: C# library for comparing two OpenAPI specifications.
   v3: true
+
+- name: AppMap OpenAPI Generation
+  category: 
+    - auto-generators
+    - documentation
+  language: Ruby / Python / Javascript / Typescript / Java
+  github: https://github.com/getappmap/appmap-js
+  link: https://appmap.io/docs/openapi
+  description: Use AppMap to auto-generate OpenAPI docs back on the runtime behavior of the code.
+  v3: true


### PR DESCRIPTION
You can use AppMap to auto-generate your OpenAPI documentation based on the runtime behavior of the code. Simply add AppMap to your project as a library dependency and either run your API tests or interact with your APIs to generate AppMaps then export this data into OpenAPI format.