### PR TITLE
bump liquid to 4.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
I encountered an issue while trying to install dependencies with ruby 3.2. Following this thread solved the issue https://github.com/github/pages-gem/issues/859

Liquid 4.0.4 is compatible with Ruby 3.2