### PR TITLE
Remove openapi4j as a recommended tool due to no longer being activel…

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1108,18 +1108,6 @@
   v2: true
   v3: true
 
-- name: openapi4j
-  category:
-    - data-validators
-    - schema-validators
-    - parsers
-  github: https://github.com/openapi4j/openapi4j
-  language: Java
-  description:
-    Parse Description Document, validate API requests and responses using
-    OpenAPI 3.x.
-  v3: true
-
 - name: oas-tools
   category:
     - security


### PR DESCRIPTION
…y maintained.

See: https://github.com/openapi4j/openapi4j/tree/master
Not sure if you want to list tools that are no longer actively maintained on the website. Thought I would raise a pr just in case.