### PR TITLE
Remove outdated/duplicated `readmeio/oas` listing

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1,13 +1,3 @@
-- name: readmeio/oas
-  category: dsl
-  language: TypeScript / CLI
-  description:
-    A language-agnostic tool for documenting your API right from your code, generating an OpenAPI Definition.
-  link: https://github.com/readmeio/oas
-  v2: true
-  v3: true
-  v3_1: false
-
 - name: oasdiff
   category: miscellaneous
   language: Go


### PR DESCRIPTION
The up-to-date information on `readmeio/oas` was added in https://github.com/apisyouwonthate/openapi.tools/pull/410, so we can safely revert https://github.com/apisyouwonthate/openapi.tools/pull/351, which is outdated. `oas` is no longer a CLI and it does indeed support OpenAPI v3.1.