### PR TITLE
fix: Restish supports Open API 3.1

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1736,6 +1736,7 @@
   github: https://github.com/danielgtaylor/restish
   description: A CLI for REST-ish APIs with HTTP/2, built-in auth, content negotiation, caching, and more that understands and can discover OpenAPI descriptions.
   v3: true
+  v3_1: true
 
 - name: openapi-examples-validator
   category:


### PR DESCRIPTION
See related release from Dec 2022: https://github.com/danielgtaylor/restish/releases/tag/v0.15.0