### PR TITLE
Update MkDocs Swagger UI Tag information

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2152,6 +2152,7 @@
     A MkDocs plugin supports for add Swagger UI in page.
   v2: true
   v3: true
+  v3_1: true
 
 - name: OpenAPI Commander
   category:


### PR DESCRIPTION
Swagger UI v5.0.0 already supports OpenAPI v3.1.0
https://github.com/swagger-api/swagger-ui/releases/tag/v5.0.0 https://blueswen.github.io/mkdocs-swagger-ui-tag/demo/openapi-v3.1/