### PR TITLE
InducoApi v2.1.0 supports OpenApi 3.1.0

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -692,6 +692,7 @@
   description:
     A simple python module to generate OpenAPI Description Documents by supplying request/response bodies.
   v3: true
+  v3_1: true
 
 - name: Connexion
   category: mock


### PR DESCRIPTION
Release [v2.1.0](https://github.com/TheWall89/inducoapi/releases/tag/v2.1.0) of InducoApi now supports OpenApi Spec 3.1.0