### PR TITLE
Fix 404 error on broken favicon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     />
     <meta name="author" content="APIs You Won't Hate" />
     <link rel="canonical" href="https://openapi.tools" />
-    <link rel="icon" href="https://v4-alpha.getbootstrap.com/favicon.ico" />
     <title>
       OpenAPI.Tools - an Open Source list of great tools for Open API
     </title>


### PR DESCRIPTION
This didn't need to be there