### PR TITLE
Add go-openapi-spec-code-diffs tool to the list

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2260,6 +2260,17 @@
   v3: true
   v3_1: true
 
+- name: go-openapi-spec-code-diffs
+  category:
+    - validator
+  link: https://github.com/RHEcosystemAppEng/go-openapi-spec-code-diffs
+  language: go
+  github: https://github.com/RHEcosystemAppEng/go-openapi-spec-code-diffs
+  description:
+    A golang validation tool that compares given OpenAPI specs (e.g. openapi.yaml) vis-a-vis routes (e.g. /api/v1/customer/:id) defined in golang source code and reports differences. This is useful in scenarios where you want to keep the OpenAPI specs and Code in synch.
+  v3: true
+  v3_1: true
+
 - name: draig
   category:
     - sdk


### PR DESCRIPTION
Request to add [`go-openapi-spec-code-diffs`](https://github.com/RHEcosystemAppEng/go-openapi-spec-code-diffs) tool. 

A golang validation tool that compares given OpenAPI specs (e.g. openapi.yaml) vis-a-vis routes (e.g. /api/v1/customer/:id) defined in golang source code and reports differences. This is useful in scenarios where you want to keep the OpenAPI specs and Code in synch.