### PR TITLE
Update category for go-openapi-spec-code-diffs

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2262,6 +2262,7 @@
 
 - name: go-openapi-spec-code-diffs
   category:
+    - miscellaneous
     - validator
   link: https://github.com/RHEcosystemAppEng/go-openapi-spec-code-diffs
   language: go


### PR DESCRIPTION
Request to update the category for go-openapi-spec-code-diffs tool, so that it can appear under `Miscellaneous` category. Thanks.