### PR TITLE
:rocket: Added a new tool - go-oas/docs

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1384,6 +1384,17 @@
     or code from descriptions!
   v2: true
 
+- name: docs
+  category:
+    - parser
+    - converters
+    - sdk
+  link: https://github.com/go-oas/docs
+  github: https://github.com/go-oas/docs
+  description: A modern alternative to `go-swagger`. Offers generation and parsing of OpenAPI Specs, depending on the usage.
+  v3: true
+  v3_1: true
+
 - name: guardrail
   category:
     - sdk


### PR DESCRIPTION
There aren't many tools in the Go ecosystem that tackle the needs of OAS generation/parsing. 
This tool is an alternative to outdated Swagger2.0 `go-swagger`. 