### PR TITLE
Updates openapi json schema generator, 3.1.0 now supported

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -377,7 +377,7 @@
     by parsing your OpenAPI Description
   v2: false
   v3: true
-  v3_1_link: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/issues/131
+  v3_1: true
 
 - name: Kiota Api Client Generator
   category:


### PR DESCRIPTION
Updates openapi json schema generator
v3.1.0 documents are now supported per: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/releases/tag/3.1.0