### PR TITLE
Add MkDocs Redoc Tag

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2146,6 +2146,16 @@
   v2: true
   v3: true
 
+- name: MkDocs Redoc Tag
+  category: documentation
+  language: Python
+  link: https://blueswen.github.io/mkdocs-redoc-tag/
+  github: https://github.com/blueswen/mkdocs-redoc-tag
+  description: A MkDocs plugin supports adding Redoc to the page.
+  v2: true
+  v3: true
+  v3_1: true
+
 - name: MkDocs Swagger UI Tag
   category: documentation
   language: Python


### PR DESCRIPTION
A MkDocs plugin supports adding [Redoc](https://github.com/Redocly/redoc) to the page.