### PR TITLE
Add openapi_first Ruby gem

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1138,6 +1138,17 @@
   v2: true
   v3: true
 
+- name: openapi_first
+  category: data-validators
+  github: https://github.com/ahx/openapi_first
+  language: Ruby
+  description:
+    It validates requests and responses against your API description using rack middlewares or a low-level interface.
+    It gives you access to request parameters that are parsed exactly as described
+    in your API description and produces useful customizable error responses if request validation fails.
+  v3: true
+  v3_1: true
+
 - name: OpenAPI Enforcer
   category:
     - data-validators


### PR DESCRIPTION
Hi. This adds https://github.com/ahx/openapi_first.


I am planning on adding converters (DateTime etc) and maybe test integration, but currently this thing does what is described here. Thanks for maintaining this list.