### PR TITLE
Updates languages supported by Openapi json schema generator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -451,7 +451,7 @@
     - code-generators
     - sdk
   link: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator
-  language: Python
+  language: Python, Java
   github: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator
   description:
     A template-driven engine to generate API client code + documentation


### PR DESCRIPTION
Openapi json schema generator now supports Python and Java
per this release:
https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/releases/tag/4.2.0