### PR TITLE
Add Swift OpenAPI Generator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2552,6 +2552,18 @@
   v3: true
   v3_1: true
 
+- name: Swift OpenAPI Generator
+  category:
+    - sdk
+    - server
+  language: Swift
+  github: https://github.com/apple/swift-openapi-generator
+  link: https://github.com/apple/swift-openapi-generator
+  description: Generate Swift client and server code from an OpenAPI document. Includes support for type-safe JSON event streaming, multipart, Swift concurrency, customizable middlewares, and pluggable HTTP libraries.
+  v2: false
+  v3: true
+  v3_1: true
+
 - name: wiretap
   category:
     - miscellaneous


### PR DESCRIPTION
## Summary

Add Apple's Swift OpenAPI Generator to the list of client and server code generators.
