### PR TITLE
Add Docusaurus JSON Schema Plugin

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -102,6 +102,19 @@
   link: https://cuelang.org/docs/integrations/openapi/
   v3: true
 
+- name: Docusaurus JSON Schema Plugin
+  category:
+    - documentation
+    - description-validator
+  link: https://jy95.github.io/docusaurus-json-schema-plugin
+  github: https://github.com/jy95/docusaurus-json-schema-plugin
+  language: TypeScript
+  description:
+    Viewer to make exploration of specs a delightful experience
+  v2: false
+  v3: false
+  v3_1: true
+
 - name: JetBrains tools (IntelliJ IDEA, PyCharm etc.)
   category: gui-editors
   language: Java, Python


### PR DESCRIPTION
- Compliant with OpenAPI 3.1
- Support multiple versions of JSON Schema ( https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0 - "$schema now allowed" ) : Draft-07 / Draft 2019-09 / Draft 2020-12

![image](https://github.com/apisyouwonthate/openapi.tools/assets/9306961/a0d8386e-6753-444b-a400-49bbad9ca212)
