### PR TITLE
Fix link to Prism homepage in tools.yml

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -709,7 +709,7 @@
 - name: Prism
   category: mock
   language: cli
-  link: https://stoplight.io/prism
+  link: https://stoplight.io/open-source/prism
   github: https://github.com/stoplightio/prism
   description:
     Turn any OAI file into an API server with mocking, transformations,


### PR DESCRIPTION
- old link is 404'ing

Before:
<img width="1512" alt="Fullscreen_12_03_2024__09_48" src="https://github.com/apisyouwonthate/openapi.tools/assets/3313870/ae4fbcfd-195b-4855-9b59-dab56a57976b">
