### PR TITLE
feat(sdk): add OpenAPI Qraft as an SDK generation tool for React

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2739,6 +2739,18 @@
   description: OpenAPI v3.1 validator and JSON Schema validator (draft7, draft2019-09, draft2020-12)
   v3_1: true
 
+- name: OpenAPI Qraft
+  category:
+    - code-generators
+    - sdk
+  github: https://github.com/OpenAPI-Qraft/openapi-qraft
+  link: https://openapi-qraft.github.io/openapi-qraft/
+  language: TypeScript
+  description: Generate a type-safe TanStack Query client for React from an OpenAPI Document.
+  v2: false
+  v3: true
+  v3_1: true
+
 - name: Mojolicious::Plugin::OpenAPI::Modern
   category:
     - server


### PR DESCRIPTION
**Proposal**
Add OpenAPI Qraft to the `code-generators` and `sdk` _category_.

**Reason**
An actively developing React API Client generator with real users.

**Impact**
More satisfied React developers.