### PR TITLE
openapi-dev-tool support OAS 2, 3, 3.1

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1051,7 +1051,9 @@
   github: https://github.com/lyra/openapi-dev-tool
   language: JavaScript
   description: "OpenAPI Dev Tool proposes to developers a unique tool to address development and industrialization needs!"
+  v2: true
   v3: true
+  v3_1: true
 
 - name: portman
   category:


### PR DESCRIPTION
Hi,

The PR is to update the support list of `openapi-dev-tool` which supports OAS 2, 3, 3.1 for now.

Regards,