### PR TITLE
Remove a duplicate "Apitive Studio" entry from the "Documentation" category

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -518,16 +518,6 @@
   description: This library facilitates creating OpenAPI document for Python projects.
   v3: true
 
-- name: Apitive Studio
-  category: documentation
-  language: Angular 7.0, Java / Saas
-  link: https://www.apitive.com
-  description: > 
-    A platform for Digital Product Managers and API Consultants to design
-    REST APIs with in-built mock and documentation.
-  v2: true
-  v3: true
-
 - name: Fix My OpenAPI - A VSCode Extension by APIMatic
   category:
   - text-editors


### PR DESCRIPTION
`tools.yml` had two identical `documentation` entries for Apitive Studio - on lines 58 and 521, which resulted in duplicate rows in the corresponding table on the website. I removed one of duplicate entries to fix the issue.

<img width="1177" alt="Screenshot 2024-04-23 at 12 02 34" src="https://github.com/apisyouwonthate/openapi.tools/assets/8576823/f163ae0e-2c12-4bb2-9e4b-d4b41a9b8da9">
