### PR TITLE
Change URL for yii2-app-api

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -920,7 +920,7 @@
     - server
     - mock
   language: PHP
-  github: https://github.com/cebe/yii2-app-api
+  github: https://github.com/php-openapi/yii2-app-api
   description: >
     Generate Server side API code with routing, models, data validation and
     database schema from an OpenAPI description. Based on Yii Framework.


### PR DESCRIPTION
I moved the tool to the php-openapi org on github, so it has a new URL.

https://github.com/php-openapi/yii2-app-api