### PR TITLE
docs: note 3.1 support for ibm validator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1090,6 +1090,7 @@
   description: Configurable and extensible validator/linter for OpenAPI documents
   v2: true
   v3: true
+  v3_1: true
 
 - name: Redocly CLI
   category:


### PR DESCRIPTION
The IBM OpenAPI Validator officially supports OpenAPI 3.1 - noting that in the data. Thanks!