### PR TITLE
Add api-fiddle

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -600,6 +600,17 @@
   v3: true
   v3_1: true
 
+- name: Api-Fiddle
+  category: gui-editors
+  language: TypeScript / Saas
+  link: https://www.api-fiddle.com/
+  description: >
+    Opinionated API design platform built for collaboration and exploration.
+    Create API designs for technical documents, specifications, and reviews. 
+  v2: false
+  v3: false
+  v3_1: true
+
 - name: Stoplight Studio
   category:
     - gui-editors


### PR DESCRIPTION
API-Fiddle is an opinionated API design tool built for collaboration and exploration. It is built around OpenAPI and supports it's users in quickly creating API definitions for technical documents, meetings, and reviews.