### PR TITLE
Added Scramble documentation generator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -181,6 +181,16 @@
   v3: true
   v3_1: true
 
+- name: Scramble
+  category: documentation
+  language: PHP
+  github: https://github.com/dedoc/scramble
+  link: https://scramble.dedoc.co/
+  description: Modern Laravel OpenAPI documentation generator. No PHPDoc annotations required.
+  v2: false
+  v3: false
+  v3_1: true
+
 - name: Scribe
   category: documentation
   link: https://scribe.knuckles.wtf/

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -182,7 +182,9 @@
   v3_1: true
 
 - name: Scramble
-  category: documentation
+  category: 
+    - auto-generators
+    - documentation
   language: PHP
   github: https://github.com/dedoc/scramble
   link: https://scramble.dedoc.co/


### PR DESCRIPTION
Scramble is OpenAPI documentation generator for Laravel. It generates API documentation for projects automatically without requiring a developer to manually write PHPDoc annotations.

https://scramble.dedoc.co