### PR TITLE
Add openapi-to-hurl

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1845,6 +1845,15 @@
   v2: true
   v3: true
 
+- name: openapi-to-hurl
+  category: converters
+  github: https://github.com/ethancarlsson/openapi-to-hurl
+  language: CLI
+  description: "A CLI to convert OpenAPI 3.1 Description Documents to hurl test files"
+  v2: false
+  v3: false
+  v3_1: true
+
 - name: openapi-to-postman
   category: converters
   github: https://github.com/postmanlabs/openapi-to-postman


### PR DESCRIPTION
openapi-to-hurl is a tool for converting openapi documents to [hurl](https://hurl.dev/) test files.

https://github.com/ethancarlsson/openapi-to-hurl