### PR TITLE
Add Hey API

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2856,4 +2856,16 @@
   v2: true
   v3: true
 
+- name: '@hey-api/openapi-ts'
+  category:
+    - converters
+    - sdk
+  description: ✨ Turn your OpenAPI specification into a beautiful TypeScript client
+  language: TypeScript
+  github: https://github.com/hey-api/openapi-ts
+  link: https://heyapi.vercel.app/
+  v2: true
+  v3: true
+  v3_1: true
+
 # Please add new entries in alphabetical order, which slightly helps reduce conflicts


### PR DESCRIPTION
[@hey-api/openapi-ts](https://github.com/hey-api/openapi-ts) is a successor to [openapi-typescript-codegen](https://github.com/ferdikoomen/openapi-typescript-codegen). It currently offers OpenAPI to TypeScript codegen functionality and some people use it for publishing their own SDKs. More features will be added as time goes on. Thank you for considering adding this project to OpenAPI tools!