### PR TITLE
feat: add django-contract-tester

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1003,6 +1003,15 @@
   v2: true
   v3: true
 
+- name: django-contract-tester
+  category: data-validators
+  github: https://github.com/maticardenas/django-contract-tester
+  language: Python
+  description: Validate Django REST Framework (DRF) and Django Ninja APIs against their OpenAPI specification.
+  v2: true
+  v3: true
+  v3_1: true
+
 - name: openapi-data-validator
   category:
     - data-validators


### PR DESCRIPTION
Adding [django-contract-tester](https://github.com/maticardenas/django-contract-tester), it's a django-exclusive tool which allows to validate [DRF](https://github.com/encode/django-rest-framework) and [Django-Ninja](https://github.com/vitalik/django-ninja) APIs against their OpenAPI specification.

One of its most useful use cases is to allow you to simply replace the [test client](https://github.com/maticardenas/django-contract-tester?tab=readme-ov-file#django-testing-client) and have all your tests performing contract validation.