### PR TITLE
Adds support for version 3.1 in express-openapi-validator

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1039,6 +1039,7 @@
   language: JavaScript
   description: "\U0001F98B Auto-validate API requests and responses in ExpressJS."
   v3: true
+  v3_1: true
 
 - name: openapi-dev-tool
   category:


### PR DESCRIPTION
Since release 5.4.0 https://github.com/cdimascio/express-openapi-validator/releases/tag/v5.4.0 express-openapi-validator supports OpenAPi version 3.1. This PR introduces this change to the table