### PR TITLE
Add rage-rb

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -144,6 +144,18 @@
   v3: true
   v3_1: true
 
+- name: Rage
+  category:
+    - auto-generators
+    - server
+  language: Ruby
+  link: https://github.com/rage-rb/rage
+  github: https://github.com/rage-rb/rage
+  description: A Ruby web framework for building APIs with first-class OpenAPI support.
+  v2: false
+  v3: true
+  v3_1: false
+
 - name: Rate My OpenAPI
   category:
     - miscellaneous


### PR DESCRIPTION
[Rage](https://github.com/rage-rb/rage) is a Ruby web framework for building APIs with first-class OpenAPI support.