### PR TITLE
Adds Framna Docs

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -116,7 +116,7 @@
   category: documentation
   link: https://github.com/shapehq/framna-docs/
   language: TypeScript
-  description: Self-hosted web portal that centralizes OpenAPI documentation and facilitates spec-driven development, built with GitHub-based authorization.
+  description: Self-hosted web portal that centralizes OpenAPI documentation and facilitates spec-driven development, built with GitHub-based authorization. Integrates with SwaggerUI, Stoplight Elements, and Redocly.
   v2: true
   v3: true
   v3_1: true

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -112,6 +112,15 @@
   v2: true
   v3: true
 
+- name: Framna Docs
+  category: documentation
+  link: https://github.com/shapehq/framna-docs/
+  language: TypeScript
+  description: Self-hosted web portal that centralizes OpenAPI documentation and facilitates spec-driven development, built with GitHub-based authorization.
+  v2: true
+  v3: true
+  v3_1: true
+
 - name: Frevo
   category:
     - documentation

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -116,7 +116,7 @@
   category: documentation
   link: https://github.com/shapehq/framna-docs/
   language: TypeScript
-  description: Self-hosted web portal that centralizes OpenAPI documentation and facilitates spec-driven development, built with GitHub-based authorization. Integrates with SwaggerUI, Stoplight Elements, and Redocly.
+  description: Self-hosted web portal that centralizes OpenAPI documentation and facilitates spec-driven development, built with GitHub-based authorization. Integrates with Swagger UI, Stoplight Elements, and Redocly.
   v2: true
   v3: true
   v3_1: true


### PR DESCRIPTION
Adds [Framna Docs](https://github.com/shapehq/framna-docs/), a tool we've built at [Shape](https://shape.dk) (soon to be [Framna](https://framna.com)) to centralize documentation and support teams in spec-driven development.

Our description documents reside in GitHub repositories, allowing teams to easily review changes. This also enables fine-grained access control, as Framna Docs uses GitHub-based authentication to display only documentation from repositories that users have access to.

Framna Docs displays documentation on any branch and tag in any repository users have access to on GitHub and enables them to choose their preferred viewer from Swagger UI, Stoplight Elements, and Redocly.