### PR TITLE
Added CodeMirror OAS support

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -83,6 +83,17 @@
   v2: true
   v3: true
 
+- name: CodeMirror OAS support
+  category: 
+    - text-editors
+    - miscellaneous
+  language: TypeScript
+  link: https://evitadb.io/download/single-file-playground.html
+  github: https://github.com/ruzito/oas-aware-rest-lang-support
+  description:
+    Plugin for text editor https://codemirror.net/ running in your browser that can fetch and parse your OpenAPI schema definition and provide auto-completion support (for large and complex JSON message payloads), error highlighting and access to schema documentation. It is capable of parsing megabytes of OpenAPI schema definition in a second and providing auto-completion support in milliseconds. The work is an MVP of a plugin with basic functionality made as part of a master thesis at ČVUT.
+  v3: true
+
 - name: Connexion
   category: server
   language: Python


### PR DESCRIPTION
Plugin for text editor https://codemirror.net/ running in your browser that can fetch and parse your OpenAPI schema definition and provide auto-completion support (for large and complex JSON message payloads), error highlighting and access to schema documentation. It is capable of parsing megabytes of OpenAPI schema definition in a second and providing auto-completion support in milliseconds. The work is an MVP of a plugin with basic functionality made as part of a master thesis at ČVUT.