### PR TITLE
added FastMCP to tools.yml

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -164,7 +164,7 @@
   category:
     - server
     - auto-generators
-  link: https://gofastmcp.com/patterns/openapi
+  link: https://gofastmcp.com/integrations/openapi#openapi-fastmcp
   github: https://github.com/jlowin/fastmcp
   description: FastMCP can automatically generate an MCP server from an OpenAPI specification. Users only need to provide an OpenAPI specification (3.0 or 3.1) and an API client.
   v2: false


### PR DESCRIPTION
Added FastMCP to the list of tools that support OpenAPI for automatic server code generation. FastMCP can automatically generate an MCP server from an OpenAPI specification. Users only need to provide an OpenAPI specification (3.0 or 3.1) and an API client.

Model details [here](https://www.linkedin.com/pulse/demystifying-model-context-protocol-mcp-how-ai-shen-phd-emba-jax5e/) on what MCP is and why it is so crucial in this moment in AI.