### PR TITLE
Remove openapi-ui

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -277,18 +277,6 @@
   v3: true
   v3_1: true
 
-- name: OpenAPI-UI
-  category: documentation
-  description:
-    Create simple and beautiful OpenAPI/Swagger documentation from OpenAPI files.
-    Generate mock parameters and call APIs. Like Postman, but for OpenAPI specifications.
-  link: https://docs.openapi-ui.com
-  github: https://github.com/rookie-luochao/openapi-ui
-  language: TypeScript
-  v2: true
-  v3: true
-  v3_1: false
-
 - name: openapi-viewer
   category: documentation
   link: https://koumoul.com/openapi-viewer/


### PR DESCRIPTION
Remove openapi-ui because the docs sub domainname isn't working anymore and the openapi-ui.com (only the one without www) is not related to any openapi.

Another option should be to point to the github page but to be honest it looks like the only activity is automated. But I can change the PR to update the link.