### PR TITLE
Update JanePHP link

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1463,7 +1463,7 @@
 - name: janephp/open-api
   category: sdk
   language: PHP
-  github: https://github.com/janephp/open-api
+  github: https://github.com/janephp/janephp
   description: Generate a PHP Client API (PSR-7 compatible) given a OpenAPI specification.
   v2: true
   v3: true


### PR DESCRIPTION
JanePHP is a monorepo, which holds the SDKs for multiple open api versions.

The original link is a project which has been deprecated, and may cause users to think JanePHP is no longer maintained.