### PR TITLE
Sort the tools by version supported

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,14 @@
             </thead>
             <tbody>
               {% assign sponsored_tools = site.data.tools | where: "sponsored", true | sort: 'sponsoredDate'  %}
-              {% assign non_sponsored_tools = site.data.tools | where_exp: "tool", "tool.sponsored == nil or tool.sponsored == false" | sort_natural: 'name' %}
+              {% assign non_sponsored_all = site.data.tools | where_exp: "tool", "tool.sponsored == nil or tool.sponsored == false" %}
+
+              {# Group by supported version, sorted by name within each group #}
+              {% assign v3_2_tools = non_sponsored_all | where: "v3_2", true | sort_natural: 'name' %}
+              {% assign v3_1_tools = non_sponsored_all | where_exp: "tool", "tool.v3_2 != true and tool.v3_1 == true" | sort_natural: 'name' %}
+              {% assign v3_tools = non_sponsored_all | where_exp: "tool", "tool.v3_2 != true and tool.v3_1 != true and tool.v3 == true" | sort_natural: 'name' %}
+              {% assign no_v3_tools = non_sponsored_all | where_exp: "tool", "tool.v3_2 != true and tool.v3_1 != true and tool.v3 != true" | sort_natural: 'name' %}
+              {% assign non_sponsored_tools = v3_2_tools | concat: v3_1_tools | concat: v3_tools | concat: no_v3_tools %}
 
               {% assign sorted_tools = sponsored_tools | concat: non_sponsored_tools %}
 


### PR DESCRIPTION
Within each category, group by supported version, sorted by name within the group. This ensures that tools that support the latest version are above those that do not.
