### PR TITLE
Add Swift OpenAPIKit parser

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1336,6 +1336,20 @@
   description: TS Model & utils for OpenAPI 3.0.x contracts
   v3: true
 
+- name: OpenAPIKit
+  category:
+    - parsers
+    - description-validators
+    - dsl
+  language: Swift
+  github: https://github.com/mattpolzin/openapikit
+  link: https://github.com/mattpolzin/openapikit
+  description: Codable Swift types that encode to- and decode from OpenAPI 3.0.x and OpenAPI 3.1.x Documents and their components.
+  v2: false
+  v3: true
+  v3_1: true
+  v3_2: false
+
 - name: kin-openapi
   category:
     - parsers


### PR DESCRIPTION
Add the Swift OpenAPIKit library to the list of parsers, DSLs, and description validators.

OpenAPIKit is the accepted standard OAS implementation for the Swift Server Workgroup's [Incubation Program](https://www.swift.org/sswg/incubated-packages.html) and it is in use by numerous other projects, most notably the [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).

It supports OAS 3.0.x and 3.1.x and support for OAS 3.2.x is under active development.