### PR TITLE
docs: Add v3_1 and v3_2 support to TypeSpec tool

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2046,6 +2046,8 @@
   github: https://github.com/microsoft/typespec
   description: Emit OpenAPI specifications from API descriptions defined in the generic, interoperable, and extensible TypeSpec language.
   v3: true
+  v3_1: true
+  v3_2: true
 
 - name: oa-client
   category:


### PR DESCRIPTION
Adds support for OAI 3.1 and 3.2 for TypeSpec.

[3.2.0 support was added to version 1.6.0](https://github.com/microsoft/typespec/releases/tag/typespec-stable%401.6.0)