### PR TITLE
Remove Alphadoc (defunct)

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1,17 +1,3 @@
-- name: Alphadoc
-  category:
-    - documentation
-    - description-validator
-  link: https://alphadoc.io
-  language: SaaS
-  description:
-    Alphadoc is a full featured developer experience platform. API components with granular parameter control and diagrams
-    generated from your OpenAPI. Not only the reference, but the entire set of tutorials and guides automatically updates when
-    the underlying API updates.
-  v2: true
-  v3: true
-  v3_1: true
-
 - name: Docuo
   category: documentation
   link: https://docuo.spreading.ai/?via=ot


### PR DESCRIPTION
Alphadoc [shut down in 2024](https://www.linkedin.com/posts/alphadoc-io_alphadoc-services-have-been-shut-down-on-activity-7230145541236514816-B3zW).