### PR TITLE
feat: add support of 3.2 spec to Redocly tools

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -772,6 +772,7 @@
   v2: true
   v3: true
   v3_1: true
+  v3_2: true
 
 - name: Api-Fiddle
   category: gui-editors
@@ -1373,6 +1374,7 @@
   v2: true
   v3: true
   v3_1: true
+  v3_2: true
 
 - name: openapi-validator-middleware
   category:


### PR DESCRIPTION
Two months ago, we added support for the 3.2 specification to the Redocly tools. We would like to update the information on this website.