### PR TITLE
fix: indentation in tools.yaml

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -75,7 +75,7 @@
   v3: true
   v3_1: true
 
-  - name: APIQuality
+- name: APIQuality
   category: monitoring
   language: SaaS
   description:


### PR DESCRIPTION
Fixed indentation in tools.yaml, which causes an error in deployment and blocks it.