### PR TITLE
Fixed wrap in banner

### DIFF
--- a/src/components/SponsorBanner.tsx
+++ b/src/components/SponsorBanner.tsx
@@ -54,7 +54,10 @@ const SponsorBanner = ({ sponsors }: { sponsors: BannerSponsor[] }) => {
           </span>
         </div>
       </a>
-      <a className="flex items-center px-2 py-1 md:justify-end" href="/sponsor">
+      <a
+        className="flex items-center px-2 py-1 text-nowrap md:justify-end"
+        href="/sponsor"
+      >
         <span className="text-white">Sponsor openapi.tools</span>
       </a>
     </section>


### PR DESCRIPTION
The banner on desktop wraps for no reason:

Before:

<img width="1594" height="164" alt="Screenshot 2026-01-10 at 9 08 53 am" src="https://github.com/user-attachments/assets/87e7d05f-6c4f-4755-961e-05a711ca54fe" />

After:

<img width="1594" height="227" alt="Screenshot 2026-01-10 at 9 08 37 am" src="https://github.com/user-attachments/assets/6c07d41d-c4eb-49d0-8d24-08ebf79c3c8d" />

Mobile stays the same no change

<img width="415" height="898" alt="Screenshot 2026-01-10 at 9 08 22 am" src="https://github.com/user-attachments/assets/81f12ea4-4dd5-4619-9bec-7bb232122213" />

