### PR TITLE
Added Pre-Fetch

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,4 +45,5 @@ export default defineConfig({
   adapter: netlify(),
   site: 'https://openapi.tools',
   trailingSlash: 'never',
+  prefetch: true,
 });

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -50,6 +50,7 @@ export function Navigation({
                     <Link
                       href={link.href}
                       onClick={onLinkClick}
+                      data-astro-prefetch
                       className={clsx(
                         'block w-full pl-3.5 before:pointer-events-none before:absolute before:top-1/2 before:-left-1 before:h-1.5 before:w-1.5 before:-translate-y-1/2 before:rounded-full',
                         link.href === pathname

--- a/src/components/QuickLink.tsx
+++ b/src/components/QuickLink.tsx
@@ -14,7 +14,7 @@ export function QuickLink({
       <div className="absolute -inset-px rounded-xl border-2 border-transparent opacity-0 [background:linear-gradient(var(--quick-links-hover-bg,theme(colors.green.50)),var(--quick-links-hover-bg,theme(colors.green.50)))_padding-box,linear-gradient(to_top,theme(colors.emerald.400),theme(colors.teal.400),theme(colors.green.500))_border-box] group-hover:opacity-100 dark:[--quick-links-hover-bg:theme(colors.slate.800)]" />
       <div className="relative overflow-hidden rounded-xl p-6">
         <h2 className="font-display mt-0 text-base text-slate-900 dark:text-white">
-          <Link href={href}>
+          <Link href={href} data-astro-prefetch>
             <span className="absolute -inset-px rounded-xl" />
             {title}
           </Link>

--- a/src/components/table/Columns.tsx
+++ b/src/components/table/Columns.tsx
@@ -42,6 +42,7 @@ export const createNameColumn = (): ColumnDef<ToolRowData> => ({
       <>
         <Link
           href={`/tools/${slug}`}
+          data-astro-prefetch
           className="group inline-flex flex-row items-center space-x-2 text-slate-800 no-underline hover:underline dark:text-slate-200"
         >
           {isSponsorshipActive(tool) && (


### PR DESCRIPTION
There is a weird layout shift bug that happens when changing pages on desktop. While pre-fetching does not fix it it does lessen its impact. (I do have a bug fix pr coming as well)

I have added pre-fetch only to internal Links so did not add them direct to the link component. Added it to:

- Navigation 
- Quick links on home page
- Name column in the table that goes to details page

Means on hover or focus of the link the page is fetched making the docs feel much faster as they are used. 

From https://docs.astro.build/en/guides/prefetch/ one of the best features of Astro is how easy they make this