### PR TITLE
Handle languages where name is different on devicon

### DIFF
--- a/src/components/Languages.tsx
+++ b/src/components/Languages.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { clsxm } from '@/utils/clsxm';
+import { getDeviconClassName } from '@/utils/languageUtils';
 
 type LanguagesProps = {
   languages: Record<string, boolean>;
@@ -26,7 +27,7 @@ const Languages: React.FC<LanguagesProps> = ({ languages }) => {
             <i
               className={clsxm(
                 'text-xl text-white',
-                `devicon-${language.toLowerCase().trim()}-plain`
+                `devicon-${getDeviconClassName(language)}-plain`
               )}
             />
           </li>

--- a/src/components/table/Columns.tsx
+++ b/src/components/table/Columns.tsx
@@ -2,6 +2,7 @@ import { type ColumnDef } from '@tanstack/react-table';
 import type { Category, Tool } from 'src/content/config';
 import { isSponsorshipActive } from 'src/utils/sponsorship';
 
+import { getDeviconClassName } from '@/utils/languageUtils';
 import Badge from '../Badge';
 import RepoIcon from '../icons/RepoIcon';
 import WebsiteIcon from '../icons/WebsiteIcon';
@@ -72,7 +73,7 @@ export const createLanguagesColumn = (): ColumnDef<ToolRowData> => ({
         {Object.keys(languages).map((language) => (
           <i
             key={language}
-            className={`devicon-${language.toLowerCase().trim()}-plain text-lg text-slate-700 dark:text-slate-300`}
+            className={`devicon-${getDeviconClassName(language)}-plain text-lg text-slate-700 dark:text-slate-300`}
             title={language}
           />
         ))}

--- a/src/utils/languageUtils.ts
+++ b/src/utils/languageUtils.ts
@@ -58,6 +58,15 @@ const LANGUAGE_NAME_MAP: Record<string, string> = {
   desktop: 'Desktop',
 };
 
+const DEVICON_NAME_MAP: Record<string, string> = {
+  golang: 'go',
+};
+
+export function getDeviconClassName(lang: string): string {
+  const lowercased = lang.toLowerCase().trim();
+  return DEVICON_NAME_MAP[lowercased] || lowercased;
+}
+
 export function formatLanguageName(lang: string): string {
   const lowercased = lang.toLowerCase();
   if (LANGUAGE_NAME_MAP[lowercased]) {


### PR DESCRIPTION
Devicon uses `go` and openapi.tools uses `golang`. This adds a mapping so the icons work for Go.