### PR TITLE
Updating Beeceptor / support for 3.x

### DIFF
--- a/src/content/tools/beeceptor-openapi-mock-server.md
+++ b/src/content/tools/beeceptor-openapi-mock-server.md
@@ -4,12 +4,13 @@ description: |
   🐝 A free service that transforms your OpenAPI description documents into instant mock servers with AI-generated realistic responses. Upload your YAML/JSON files to get schema-compliant mocks without writing any code. Helps with early integration testing and simulating various API behaviors.
 categories:
   - mocking
+  - docs
 link: https://beeceptor.com/openapi-mock-server/
 languages:
   saas: true
 oasVersions:
   v2: false
   v3: true
-  v3_1: false
-  v3_2: false
+  v3_1: true
+  v3_2: true
 ---


### PR DESCRIPTION
Beeceptor author here. Beeceptor supports OpenAPI spec mocking for 3.1 and 3.2 specs, and hosting as docs.

Reference: https://beeceptor.com/openapi-mock-server/