### PR TITLE
Fix nest-openapi/mock category

### DIFF
--- a/src/content/tools/nest-openapi-mock.md
+++ b/src/content/tools/nest-openapi-mock.md
@@ -2,7 +2,7 @@
 name: '@nest-openapi/mock'
 description: Spec-driven mock server for NestJS that generates realistic mock responses from OpenAPI.
 categories:
-  - mocking-tools
+  - mocking
 link: https://nest-openapi.github.io/mock/
 languages:
   typescript: true


### PR DESCRIPTION
It didn't appeared in the site, figured out the category was miss-spelled.
Also would be good to run something like a schema check in CI for tool contents to avoid these kind of issues.
Thanks in advance.