### PR TITLE
Add arazzo-cli

### DIFF
--- a/src/content/tools/arazzo-cli.md
+++ b/src/content/tools/arazzo-cli.md
@@ -1,0 +1,44 @@
+---
+name: 'arazzo-cli'
+description: 'Standalone Arazzo 1.0 workflow executor with runtime engine, debugger, and MCP server for AI agent integration.'
+categories:
+  - testing
+  - mcp
+languages: { 'Rust': true }
+link: 'https://github.com/strefethen/arazzo-cli'
+repo: 'https://github.com/strefethen/arazzo-cli'
+oaiSpecs:
+  oas: true
+  overlays: false
+  arazzo: true
+oasVersions:
+  v2: false
+  v3: true
+  v3_1: true
+  v3_2: false
+---
+
+## Overview
+
+arazzo-cli executes Arazzo 1.0 API workflow specifications — chained, multi-step API test sequences with expressions, control flow, and authentication. It includes a runtime engine, VS Code debugger, and an MCP server that exposes OpenAPI introspection and workflow generation as AI-agent tools.
+
+## Features
+
+- Execute Arazzo workflows against live APIs with chained step outputs
+- Generate CRUD workflows from OpenAPI specs with realistic example values
+- MCP server with 7 tools for AI agent integration (describe, generate, run)
+- VS Code debug adapter with breakpoints and step-through
+- Dry-run mode, parallel execution, JSON output, trace recording
+
+## Usage
+
+\`\`\`bash
+# Validate a spec
+arazzo-cli validate my-workflow.arazzo.yaml
+
+# Run a workflow
+arazzo-cli run my-workflow.arazzo.yaml workflow-id -i key=value
+
+# Generate workflows from OpenAPI
+arazzo-cli generate --spec petstore.openapi.yaml
+\`\`\`

--- a/src/content/tools/arazzo-cli.md
+++ b/src/content/tools/arazzo-cli.md
@@ -34,12 +34,16 @@ arazzo-cli executes Arazzo 1.0 API workflow specifications — chained, multi-st
 ## Usage
 
 \`\`\`bash
+
 # Validate a spec
+
 arazzo-cli validate my-workflow.arazzo.yaml
 
 # Run a workflow
+
 arazzo-cli run my-workflow.arazzo.yaml workflow-id -i key=value
 
 # Generate workflows from OpenAPI
+
 arazzo-cli generate --spec petstore.openapi.yaml
 \`\`\`

--- a/src/content/tools/arazzo-cli.md
+++ b/src/content/tools/arazzo-cli.md
@@ -4,6 +4,7 @@ description: Standalone Arazzo 1.0 workflow executor with runtime engine, debugg
 categories:
   - testing
   - mcp
+  - data-validators
 link: https://github.com/strefethen/arazzo-cli
 languages:
   cli: true

--- a/src/content/tools/arazzo-cli.md
+++ b/src/content/tools/arazzo-cli.md
@@ -1,15 +1,15 @@
 ---
-name: 'arazzo-cli'
-description: 'Standalone Arazzo 1.0 workflow executor with runtime engine, debugger, and MCP server for AI agent integration.'
+name: arazzo-cli
+description: Standalone Arazzo 1.0 workflow executor with runtime engine, debugger, and MCP server for AI agent integration.
 categories:
   - testing
   - mcp
-languages: { 'Rust': true }
-link: 'https://github.com/strefethen/arazzo-cli'
-repo: 'https://github.com/strefethen/arazzo-cli'
+link: https://github.com/strefethen/arazzo-cli
+languages:
+  cli: true
+repo: https://github.com/strefethen/arazzo-cli
 oaiSpecs:
   oas: true
-  overlays: false
   arazzo: true
 oasVersions:
   v2: false


### PR DESCRIPTION
Adds [arazzo-cli](https://github.com/strefethen/arazzo-cli) — a standalone Arazzo 1.0 workflow executor written in Rust.

- **Categories:** testing, mcp
- **Arazzo support:** yes (first-class — Arazzo is the primary spec format)
- **OAS versions:** 3.0, 3.1
- **Language:** CLI (Rust)

Features include a runtime engine, CRUD workflow generation from OpenAPI specs, VS Code debug adapter, and an MCP server with 7 tools for AI agent integration.