### PR TITLE
Fix arazzo-cli website link

### DIFF
--- a/src/content/tools/arazzo-cli.md
+++ b/src/content/tools/arazzo-cli.md
@@ -5,7 +5,7 @@ categories:
   - testing
   - mcp
   - data-validators
-link: https://github.com/strefethen/arazzo-cli
+link: https://strefethen.github.io/arazzo-cli/
 languages:
   cli: true
 repo: https://github.com/strefethen/arazzo-cli


### PR DESCRIPTION
The `link` field for arazzo-cli was pointing to the GitHub repo URL instead of the project website. The repo URL is already correctly set in the `repo` field.

**Before:** `link: https://github.com/strefethen/arazzo-cli`  
**After:** `link: https://strefethen.github.io/arazzo-cli/`