### PR TITLE
Add Agentify — OpenAPI to agent interface compiler

### DIFF
--- a/src/content/tools/agentify.md
+++ b/src/content/tools/agentify.md
@@ -1,0 +1,32 @@
+---
+name: Agentify
+description: An agent interface compiler that transforms OpenAPI specifications into 9 agent-ready formats including MCP servers, AGENTS.md, CLAUDE.md, .cursorrules, Skills, llms.txt, GEMINI.md, A2A Card, and standalone CLI. Supports tiered generation strategies for APIs of any size.
+categories:
+  - mcp
+  - code-generators
+link: https://www.npmjs.com/package/agentify-cli
+languages:
+  typescript: true
+repo: https://github.com/koriyoshi2041/agentify
+oasVersions:
+  v2: true
+  v3: true
+  v3_1: true
+  v3_2: false
+---
+
+Agentify compiles a single OpenAPI specification into a complete suite of agent interface formats, so that any AI coding assistant or agent framework can interact with your API natively.
+
+Run a single command to generate all supported formats:
+
+```
+npx agentify-cli transform <openapi-spec-url>
+```
+
+Key features include:
+
+- **9 output formats**: MCP Server, AGENTS.md, CLAUDE.md, .cursorrules, Skills JSON, llms.txt, GEMINI.md, A2A Card, and standalone CLI
+- **Tiered generation**: Automatically selects the right strategy based on API size — direct tools for small APIs (<30 endpoints), tool search and lazy loading for medium APIs (30-100), and code execution with docs search for large APIs (100+)
+- **Swagger 2.0 and OpenAPI 3.x**: Parses both legacy Swagger and modern OpenAPI descriptions
+- **Security-first**: Input sanitization of all spec fields, generated code scanning, and no eval/exec in output
+- **MIT licensed**: Fully open source


### PR DESCRIPTION
## Summary

- Adds [Agentify](https://github.com/koriyoshi2041/agentify) (`agentify-cli` on npm) to the tools directory
- Categorized under **MCP** and **Code generators**
- Agentify is an open-source TypeScript CLI that compiles a single OpenAPI spec into 9 agent interface formats: MCP Server, AGENTS.md, CLAUDE.md, .cursorrules, Skills JSON, llms.txt, GEMINI.md, A2A Card, and standalone CLI
- Supports OpenAPI 3.x and Swagger 2.0
- MIT licensed, 133 tests passing

## Why this tool belongs here

No existing tool in the directory generates multiple agent interface formats from a single OpenAPI spec. Current MCP-category tools (FastMCP, Gram) focus on MCP server generation only. Agentify covers MCP plus 8 additional formats used by AI coding assistants (Claude Code, Cursor, Gemini, etc.) and agent frameworks (A2A, Skills).

## Usage

```
npx agentify-cli transform <openapi-spec-url>
```

## Links

- **GitHub**: https://github.com/koriyoshi2041/agentify
- **npm**: https://www.npmjs.com/package/agentify-cli