### PR TITLE
Add oaswrap/spec — Go OpenAPI 3.x specification builder

### DIFF
--- a/src/content/tools/oaswrap-spec.md
+++ b/src/content/tools/oaswrap-spec.md
@@ -1,0 +1,15 @@
+---
+name: oaswrap/spec
+description: A lightweight, framework-agnostic OpenAPI 3.x specification builder for Go that generates API docs programmatically using pure Go code without annotations.
+categories:
+  - openapi-aware-frameworks
+link: https://oaswrap.github.io/docs/spec/introduction
+languages:
+  golang: true
+repo: https://github.com/oaswrap/spec
+oasVersions:
+  v2: false
+  v3: true
+  v3_1: true
+  v3_2: false
+---


### PR DESCRIPTION
- Adds oaswrap/spec to the openapi-aware-frameworks category 
- A lightweight, framework-agnostic OpenAPI 3.x spec builder for Go
- Generates API documentation programmatically using pure Go code — no annotations or comments required
- Supports OpenAPI v3.0 and v3.1, works with popular Go frameworks (Chi, Echo, Gin, Fiber, etc.) 