### PR TITLE
Add VSCode Simple OpenAPI Viewer documentation

### DIFF
--- a/src/content/tools/vscode-simple-openapi-viewer.md
+++ b/src/content/tools/vscode-simple-openapi-viewer.md
@@ -1,0 +1,34 @@
+---
+name: VSCode Simple OpenAPI Viewer
+description: Quick preview OpenAPI documents in Visual Studio Code & its forks.
+categories:
+  - docs
+link: https://marketplace.visualstudio.com/items?itemName=RahulDhole.simple-openapi-viewer
+languages:
+  yaml: true
+  json: true
+repo: https://github.com/rahuldhole/simple-openapi-viewer
+oasVersions:
+  v2: true
+  v3: true
+  v3_1: true
+  v3_2: true
+---
+
+## Overview
+
+A lightweight, powerful, and theme-aware VS Code extension to preview OpenAPI YAML and JSON files using a high-fidelity Swagger UI. It works entirely offline with local assets, ensuring your API definitions never leave your environment.
+
+## Features
+
+- **High-Fidelity Rendering**: Full Swagger UI integration for a professional experience.
+- **Theme Aware**: Seamlessly adjusts to your VS Code dark and light themes.
+- **Offline Ready**: No CDN dependencies; uses local assets for maximum privacy and speed.
+- **Auto-Detection**: Smartly recognises OpenAPI/Swagger files to stay out of your way when not needed.
+
+## Usage
+
+- Command Palette (`Cmd+Alt+O` / `Ctrl+Alt+O`)
+- Editor title button (quick-access icon)
+- Explorer context menu (right-click any YAML/JSON)
+- Editor context menu


### PR DESCRIPTION
Add documentation for VSCode Simple OpenAPI Viewer extension, detailing its features, usage, and links to the marketplace and repository.