### PR TITLE
Add SchemaWatch — API schema monitoring and quality scoring

### DIFF
--- a/src/content/tools/schemawatch.md
+++ b/src/content/tools/schemawatch.md
@@ -1,0 +1,48 @@
+---
+name: 'SchemaWatch'
+description: 'Monitor third-party API schemas for breaking changes. Get quality scores, track historical versions, and get alerted before production breaks.'
+categories:
+  - monitoring
+  - schema-validators
+languages: { 'Python': true }
+link: 'https://schemawatch.tuvia.nl'
+repo: 'https://github.com/ovoWeb/tuvia'
+oaiSpecs:
+  oas: true
+  overlays: false
+  arazzo: false
+oasVersions:
+  v2: true
+  v3: true
+  v3_1: true
+  v3_2: false
+---
+
+## Overview
+
+SchemaWatch is an API schema monitoring tool that crawls third-party API specifications (OpenAPI/Swagger), detects breaking changes, and alerts teams before production breaks. It maintains historical schema versions in an append-only database, creating a data moat that grows more valuable over time.
+
+## Features
+
+- **Quality Scoring** — Get an A-F grade for any OpenAPI spec with detailed category breakdowns (Completeness, Consistency, Documentation, Security, Best Practices, Machine Readability)
+- **Breaking Change Detection** — Automatically detect removed endpoints, changed parameters, modified response schemas, and other breaking changes
+- **Historical Tracking** — Store every version of every schema, enabling diff views between any two points in time
+- **Email Alerts** — Get notified when schemas change, with configurable alert thresholds
+- **Free Validator** — Validate any OpenAPI/Swagger spec URL instantly, no signup required
+- **API Quality Leaderboard** — See how popular APIs rank by spec quality (Stripe, GitHub, Slack, Twilio, etc.)
+- **Embeddable Badges** — Show your API quality score in your README with SVG badges
+
+## Usage
+
+1. Visit [schemawatch.tuvia.nl/validate](https://schemawatch.tuvia.nl/validate)
+2. Paste any OpenAPI/Swagger spec URL
+3. Get instant quality score and analysis
+4. Optionally sign up for free monitoring (3 APIs)
+
+### API Access
+
+```bash
+curl -X POST https://schemawatch.tuvia.nl/api/v1/validate \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://petstore3.swagger.io/api/v3/openapi.json"}'
+```


### PR DESCRIPTION
## Summary

Adds [SchemaWatch](https://schemawatch.tuvia.nl) to the monitoring and schema-validators categories.

SchemaWatch is a free tool that:
- Validates any OpenAPI/Swagger spec and gives an A-F quality grade
- Monitors APIs for breaking changes with historical version tracking
- Provides a public API quality leaderboard (Stripe, GitHub, Slack, etc.)
- Offers embeddable quality badges for READMEs

### Why it belongs on OpenAPI.Tools

- **Free validator** — no signup required, paste any spec URL and get instant analysis
- **Quality scoring** — 6 categories (Completeness, Consistency, Documentation, Security, Best Practices, Machine Readability)
- **Monitoring** — crawls APIs on schedule, detects breaking changes, sends email alerts
- **OpenAPI 2.0 + 3.x support** — handles both Swagger and OpenAPI specs

### Links

- **Live tool:** https://schemawatch.tuvia.nl/validate
- **API docs:** https://schemawatch.tuvia.nl/api/v1/spec
- **Source:** https://github.com/ovoWeb/tuvia