### PR TITLE
Fix layout

### DIFF
--- a/src/pages/tools/[...slug].astro
+++ b/src/pages/tools/[...slug].astro
@@ -231,7 +231,7 @@ const toolBadges = tool.data.badges
       </div>
     </PageHeader>
     <main
-      class="prose prose-lg dark:prose-invert prose-headings:text-slate-700/90 dark:prose-headings:text-slate-300/90"
+      class="prose prose-lg dark:prose-invert prose-headings:text-slate-700/90 dark:prose-headings:text-slate-300/90 mt-8"
     >
       <Content />
 


### PR DESCRIPTION
When people add extra markdown, it was hugging the details box so I added some spacing.

## Before
<img width="1542" height="761" alt="Screenshot 2026-05-15 at 10 07 12 am" src="https://github.com/user-attachments/assets/f267fee9-1a71-4bba-8ec3-54847dd9e8a9" />

## After
<img width="1138" height="946" alt="Screenshot 2026-05-15 at 10 14 30 am" src="https://github.com/user-attachments/assets/0e857c47-1833-428e-aa1a-26ef6ee0b92a" />
