### PR TITLE
Add OpenAPI Laravel

### DIFF
--- a/src/content/tools/openapi-laravel.md
+++ b/src/content/tools/openapi-laravel.md
@@ -1,0 +1,15 @@
+---
+name: OpenAPI Laravel
+description: Generates Laravel models (spatie/laravel-data classes, validation rules, backed enums) and a server scaffold from an OpenAPI description. Design-first, the API description is the source of truth.
+categories:
+  - code-generators
+languages:
+  php: true
+link: https://openapi-laravel.codewithagents.de
+repo: https://github.com/codewithagents/openapi-laravel
+oasVersions:
+  v2: false
+  v3: true
+  v3_1: true
+  v3_2: false
+---


### PR DESCRIPTION
Hi! This adds [OpenAPI Laravel](https://github.com/codewithagents/openapi-laravel), a design-first generator for the Laravel ecosystem: it takes an OpenAPI description and generates spatie/laravel-data model classes with spec-derived validation rules, backed enums, readOnly/writeOnly handling, and an optional server scaffold (abstract controllers plus a routes file typed by the generated Data classes). It is MIT licensed, actively maintained, available on [Packagist](https://packagist.org/packages/codewithagents/openapi-laravel), has a [docs site](https://openapi-laravel.codewithagents.de), and every release is gated on a corpus of 128 real-world OpenAPI descriptions generating valid PHP.

Thanks for maintaining this list!