### PR TITLE
Add Keymaker (OpenAPI → MCP server + llms.txt + agent signup)

### DIFF
--- a/src/content/tools/keymaker.md
+++ b/src/content/tools/keymaker.md
@@ -1,0 +1,26 @@
+---
+name: Keymaker
+description: Generates an agent-ready stack from an OpenAPI description — a runnable MCP server (stdio and Streamable HTTP), llms.txt, and an auth.md agent-signup endpoint issuing scoped, hashed, metered API keys. Also produces a curation report flagging weakly documented operations.
+categories:
+  - mcp
+  - code-generators
+languages:
+  javascript: true
+  nodejs: true
+  cli: true
+repo: https://github.com/adityaaa-IIT-BHU/keymaker
+oasVersions:
+  v2: false
+  v3: true
+  v3_1: true
+  v3_2: false
+---
+
+Keymaker turns an OpenAPI description into everything an AI agent needs to discover, sign up for, and call an API:
+
+- **MCP server** — every operation exposed as a tool, runnable over stdio or served as hosted Streamable HTTP
+- **llms.txt** — an agent-readable API overview
+- **auth.md + agent signup** — a `/agent-auth` endpoint issuing scoped, hashed, usage-metered API keys, following the auth.md pattern, with optional Stripe usage-based billing
+- **Curation report** — flags operations and parameters with missing or weak documentation, since generated tools are only as good as the descriptions behind them
+
+MIT licensed, plain Node.js (18+). The generated gateway can also be mounted inside an existing `node:http` or Express app.


### PR DESCRIPTION
Adds Keymaker, a CLI that generates an agent-ready stack from an OpenAPI description: a runnable MCP server (stdio and Streamable HTTP), llms.txt, and an auth.md-pattern agent-signup endpoint issuing scoped, hashed, metered API keys. It also emits a curation report flagging weakly documented operations, since generated MCP tools are only as good as the descriptions behind them.

It is a new open-source project (MIT, Node.js 18+), testable from the repo with `node src/cli.js generate examples/todo-api.yaml -o out/todo`. Listed under `mcp` and `code-generators`, following the schema of existing entries.