### PR TITLE
Membrane API Gateway: enable OpenAPI 3.2 support

### DIFF
--- a/src/content/tools/membrane-api-gateway.md
+++ b/src/content/tools/membrane-api-gateway.md
@@ -12,5 +12,5 @@ oasVersions:
   v2: true
   v3: true
   v3_1: true
-  v3_2: false
+  v3_2: true
 ---


### PR DESCRIPTION
Sets `v3_2: true` for Membrane API Gateway.

OpenAPI 3.2 support was finally added in **version 7.3.0**, which introduced support for OpenAPI 3.2 specifications for request and response validation.

Release: https://github.com/membrane/api-gateway/releases/tag/v7.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)