### PR TITLE
Add OpenAPI Generator for Angular 22 (code generator)

### DIFF
--- a/src/content/tools/openapi-generator-angular22.md
+++ b/src/content/tools/openapi-generator-angular22.md
@@ -1,0 +1,16 @@
+---
+name: OpenAPI Generator for Angular 22
+description: Generates modern Angular 22 and TypeScript client code from an OpenAPI description. Emits signal-based httpResource functions for GET operations (or classical HttpClient Observables), inject()-based standalone services for mutations, and readonly response models. Runs on the OpenAPI Generator toolchain (CLI, Maven, Gradle) and is published to Maven Central.
+categories:
+  - code-generators
+  - sdk-generators
+link: https://github.com/ls1intum/openapi-generator-angular22
+languages:
+  typescript: true
+repo: https://github.com/ls1intum/openapi-generator-angular22
+oasVersions:
+  v2: false
+  v3: true
+  v3_1: true
+  v3_2: false
+---


### PR DESCRIPTION
Adds **OpenAPI Generator for Angular 22** to the code generators list.

A custom generator for the OpenAPI Generator toolchain (`generatorName: angular22`) that produces idiomatic **Angular 22 + TypeScript** clients:

- Signal-based `httpResource` functions for GET operations (or classical `HttpClient` Observables, configurable)
- `inject()`-based standalone services (`providedIn: 'root'`) for mutations
- `readonly` response models, mutable input DTOs
- Enums as string-literal unions plus a runtime `const` object

**Testable / released:** published to Maven Central (`de.tum.cit.aet:openapi-generator-angular22:1.0.0`) and available as a GitHub Release JAR, usable from the CLI, Maven, and Gradle. MIT licensed.

Repo: https://github.com/ls1intum/openapi-generator-angular22

Note: it is a new release; happy to adjust categories/description or hold if you prefer more adoption evidence first.