### PR TITLE
feat: oapi-codegen now supports 3.1

### DIFF
--- a/src/content/tools/oapi-codegen.md
+++ b/src/content/tools/oapi-codegen.md
@@ -11,6 +11,6 @@ repo: https://github.com/deepmap/oapi-codegen
 oasVersions:
   v2: false
   v3: true
-  v3_1: false
+  v3_1: true
   v3_2: false
 ---


### PR DESCRIPTION
see https://github.com/oapi-codegen/oapi-codegen/releases/tag/v2.8.0