### PR TITLE
Add Routebase (OpenAPI-native API lifecycle platform)

### DIFF
--- a/src/content/tools/routebase.md
+++ b/src/content/tools/routebase.md
@@ -1,0 +1,36 @@
+---
+name: Routebase
+description: Routebase is an OpenAPI-native platform that keeps your API as a single source of truth. Teams design their OpenAPI description in a visual editor, then generate documentation portals, mock servers, contract tests, and drift monitoring from that one description. Change the description, publish, and Routebase flags whatever drifted. Every workspace also ships a built-in Model Context Protocol (MCP) server, so AI agents work from the same OpenAPI description.
+categories:
+  - docs
+  - mocking
+  - testing
+  - monitoring
+  - mcp
+link: https://routebase.dev/
+languages:
+  saas: true
+oaiSpecs:
+  oas: true
+  overlays: false
+  arazzo: false
+oasVersions:
+  v2: false
+  v3: true
+  v3_1: true
+  v3_2: false
+---
+
+## Overview
+
+Routebase unifies the API lifecycle around one OpenAPI description. Documentation portals, mock servers, contract tests, and monitoring all derive from the same source, so they never drift apart. A built-in MCP server exposes the same workspace to AI agents under a team's permissions.
+
+## Features
+
+- Visual editor for OpenAPI descriptions — endpoints, schemas, and versions without hand-edited YAML
+- Documentation portals generated from the description, on your own custom domain
+- Mock servers generated straight from the description, with custom rules and proxy mode
+- Contract testing that validates live responses against the description and flags drift
+- Scheduled monitoring with field-level breaking-change detection
+- Spec branches with review and merge, plus breaking-change checks
+- Built-in Model Context Protocol (MCP) server for AI-agent access


### PR DESCRIPTION
Adds **Routebase** to the list.

Routebase is an OpenAPI-native platform that keeps an API as a single source of truth: teams design their OpenAPI description in a visual editor, then generate documentation portals, mock servers, contract tests, and drift monitoring from that one description. Every workspace also ships a built-in MCP server, so AI agents work from the same OpenAPI description.

**Categories:** `docs`, `mocking`, `testing`, `monitoring`, `mcp`

Against the contribution guidelines:
- **Testable** — live SaaS with a free tier (no credit card) at https://app.routebase.dev; sign up and import or design an OpenAPI description to try the docs portal, mock server, and contract tests.
- **Relevant** — OpenAPI 3.0 / 3.1 native; the documentation, mocks, tests, and monitoring all derive from the OpenAPI description.
- **Terminology** — the description follows the OpenAPI Glossary ("OpenAPI description").
- **Real-world use** — publicly launched in July 2026. It's a young product, so I'm happy to hold this PR until there's more evidence of adoption if you'd prefer.

Website: https://routebase.dev/