### PR TITLE
Add Gesso

### DIFF
--- a/src/content/tools/gesso.md
+++ b/src/content/tools/gesso.md
@@ -1,0 +1,15 @@
+---
+name: Gesso
+description: Framework-agnostic OpenAPI contract testing for PHPUnit that validates requests and responses against your OpenAPI description and reports which endpoints, statuses, and content types your tests actually cover. Ships Laravel, Symfony, Pest, and PSR-7 adapters.
+categories:
+  - testing
+link: https://studio-design.github.io/gesso/
+languages:
+  php: true
+repo: https://github.com/studio-design/gesso
+oasVersions:
+  v2: false
+  v3: true
+  v3_1: true
+  v3_2: true
+---


### PR DESCRIPTION
## What is it?

[Gesso](https://github.com/studio-design/gesso) is framework-agnostic OpenAPI contract testing for PHP / PHPUnit. It validates requests and responses against an OpenAPI 3.0 / 3.1 / 3.2 description, and — unlike the existing PHP validators — tracks which endpoints, statuses, and content types the test suite actually exercised, reporting coverage as Markdown / JUnit XML / JSON / HTML. First-class adapters for Laravel, Symfony, Pest, and PSR-7.

## Against the contribution guidelines

- **Testable**: released on Packagist as [`studio-design/gesso`](https://packagist.org/packages/studio-design/gesso), with CI-tested five-minute quickstarts for [core PHPUnit](https://studio-design.github.io/gesso/quickstarts/core), [Laravel](https://studio-design.github.io/gesso/quickstarts/laravel), [Symfony](https://studio-design.github.io/gesso/quickstarts/symfony), and [Pest](https://studio-design.github.io/gesso/quickstarts/pest).
- **Real-world use**: an honest note — this is a young project (~4.5k downloads across the current package and its former name `studio-design/openapi-contract-testing`). As quality evidence I'd offer instead: schema conversion is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite) (3,784 cases, with the 11 deliberate verdict deltas individually documented) and every OpenAPI Initiative example document for 3.0/3.1/3.2 loads cleanly — both corpora pinned by commit SHA and enforced in CI. See [docs/conformance.md](https://github.com/studio-design/gesso/blob/main/docs/conformance.md). Happy to come back later if you'd rather wait for adoption numbers.
- **Format**: the entry mirrors `spectator.md` / `openapi-psr7-validator.md` and validates against `ToolSchema`.

Disclosure: I maintain the tool.