### PR TITLE
Add SpecShield

### DIFF
--- a/src/content/tools/specshield.md
+++ b/src/content/tools/specshield.md
@@ -1,0 +1,24 @@
+---
+name: SpecShield
+description: Contract compatibility testing for APIs. Compares two OpenAPI
+  descriptions to detect breaking changes, verifies provider descriptions against
+  consumer contracts, and gates deployments in CI with can-i-deploy. Also provides
+  governance rulesets, GitHub pull request checks, and an MCP server for AI agents.
+categories:
+  - misc
+  - schema-validators
+link: https://specshield.io
+languages:
+  any: true
+  cli: true
+repo: https://github.com/specshield-io/specshield-cli
+oaiSpecs:
+  oas: true
+  overlays: false
+  arazzo: false
+oasVersions:
+  v2: true
+  v3: true
+  v3_1: true
+  v3_2: false
+---


### PR DESCRIPTION
SpecShield is a contract compatibility testing tool for OpenAPI. It compares two OpenAPI descriptions to detect breaking changes, verifies a provider description against consumer contracts, and gates deployments in CI via `can-i-deploy`.

Against the contribution guidelines:

- **Real-world use** — ~7,400 npm downloads over the last 12 months, ~1,900 in the last 30: https://www.npmjs.com/package/specshield
- **Testable** — published on npm and usable with no account: `npx specshield compare old.yaml new.yaml`. There is also a free, no-login comparison at https://specshield.io/diff if you would rather not install anything to review this.
- **Relevant** — OpenAPI-native, MIT licensed.
- **Terminology** — I have used "OpenAPI description" throughout per the glossary; please correct me if I have slipped anywhere.

**Categories:** `misc` and `schema-validators` — matching where the other change-detection tools sit (oasdiff, openapi-diff, api-smart-diff) and vacuum's use of `schema-validators` for linting. Happy to move it if you would place it differently. One note: `bdct verify-provider` does execute requests against a live provider and validate the responses against the description, so `testing` may also apply — your call.

**Version support** — `v2: true` is included because the parser accepts Swagger 2.0 documents; I verified a 2.0-to-2.0 comparison end to end before claiming it. `v3_2` is left `false` as I have no 3.2-specific handling to point to.