### PR TITLE
Recategorise SpecShield: add security and mcp, drop misc

### DIFF
--- a/src/content/tools/specshield.md
+++ b/src/content/tools/specshield.md
@@ -5,8 +5,9 @@ description: Contract compatibility testing for APIs. Compares two OpenAPI
   consumer contracts, and gates deployments in CI with can-i-deploy. Also provides
   governance rulesets, GitHub pull request checks, and an MCP server for AI agents.
 categories:
-  - misc
   - schema-validators
+  - security
+  - mcp
 link: https://specshield.io
 languages:
   any: true


### PR DESCRIPTION
Follow-up to #816 — thanks for merging that one.

Having read the category descriptions properly, two of them fit SpecShield better than `misc` does:

**`security`** — *"By poking around your OpenAPI description, some tools can look out for attack vectors you might not have noticed."*

SpecShield ships an OWASP rule pack that checks exactly this in the description: non-HTTPS servers, missing `security` field, credentials passed in query strings, and HTTP Basic auth.

**`mcp`** — *"Tools that generate or work with Model Context Protocol (MCP) servers."*

SpecShield publishes one, on npm and the MCP registry, so an AI agent can run the compatibility and governance checks before opening a PR.

With those two added, `misc` isn't needed any more — happy to keep it if you'd rather, it just seemed redundant given the description says it's for things that "hasn't quite got enough to warrant its own category."

`schema-validators` is unchanged.

One category I deliberately did **not** add: `testing`. Its description is about executing API requests and validating responses at runtime, and SpecShield doesn't do that — it compares descriptions statically. Flagging it in case it looked like an obvious omission.
